### PR TITLE
Complete LuisaRender install instructions.

### DIFF
--- a/source/user_guide/overview/installation.md
+++ b/source/user_guide/overview/installation.md
@@ -141,7 +141,16 @@ git submodule update --init --recursive
         cmake --build build -j $(nproc)
         ```
         The `CONDA_INCLUDE_PATH` typically looks like: `/home/user/anaconda3/envs/genesis/include`
-### 4. FAQs
+
+### 4. Install
+- Link the build files into the `ext` folder of your `genesis` install, so that python can import it
+    ```
+    PYTHON_PKG_PATH=$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
+    cd .. # you should now be in `genesis/ext`
+    ln -s $PWD/LuisaRender $PYTHON_PKG_PATH/genesis/ext
+    ```
+
+### 5. FAQs
 - Assertion 'lerror’ failed: Failed to write to the process: Broken pipe:
   You may need to use CUDA of the same version as compiled.
 - if you followed 2.A and see "`GLIBCXX_3.4.30` not found"


### PR DESCRIPTION
Hi,
I installed genesis-world via pip, and then compiled LuisaRender.
In the current instructions, the build files never get moved into python's site-packages, so genesis cannot import it.
I added the instructions for installation by linking LuisaRender from genesis/ext to genesis/ext/LuisaRender in python's site-packages dir.

I used this method, because genesis assumes this relative path for LuisaRender, so just adding the .so files to the path does not work. :(
```bash
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: cannot make canonical path: No such file or directory [/home/paul/miniforge3/envs/genesis/lib/python3.10/site-packages/genesis/ext/LuisaRender/build/bin]
```

Careful, this could conflict with this PR:
https://github.com/Genesis-Embodied-AI/Genesis/pull/163

Best,
Paul