### PR TITLE
(ja_version) Fix video tag rendering in `beyond_rigid_bodies.md`

### DIFF
--- a/source/user_guide/getting_started/beyond_rigid_bodies.md
+++ b/source/user_guide/getting_started/beyond_rigid_bodies.md
@@ -311,6 +311,7 @@ for i in range(horizon):
 ```
 
 期待されるレンダリング結果：
+
 <video preload="auto" controls="True" width="100%">
 <source src="https://github.com/Genesis-Embodied-AI/genesis-doc/raw/main/source/_static/videos/pbd_cloth.mp4" type="video/mp4">
 </video>


### PR DESCRIPTION
Hello,

In the [PBD cloth simulation section](https://genesis-world.readthedocs.io/ja/latest/user_guide/getting_started/beyond_rigid_bodies.html#pbd-position-based-dynamics) at the bottom of the `beyond_rigid_bodies.md` file, the video was not rendering correctly as the source tag appeared outside the video element in the generated HTML.

Added a blank line before the video tag to ensure proper Markdown parsing.

Thanks!