### PR TITLE
Fix API class documentation

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -6,6 +6,9 @@ if os.path.isdir(os.path.join(_local_repo_root, "genesis")):
     sys.path.insert(0, _local_repo_root)
 import genesis as gs
 
+# We need to initialize Genesis before we can import any of it's classes to document
+gs.init(backend=gs.cpu)
+
 __version__ = gs.__version__
 # Configuration file for the Sphinx documentation builder.
 #


### PR DESCRIPTION
Fixes: 
* https://github.com/Genesis-Embodied-AI/genesis-doc/issues/78
* https://github.com/Genesis-Embodied-AI/Genesis/issues/2186

Genesis version 0.3.5 stopped allowing classes to be imported before Genesis initialization. This lead autodoc to fail with the exception: `Genesis hasn't been initialized. Did you call `gs.init()`. The quick fix is to initialize GS at the top of the `conf.py`. 

In the future, this might fail if support for the CPU backend is dropped, because I'm not sure readthedocs servers have appropriate GPUs. At that point, the documentation system might need to move to static analysis with [sphinx-autodoc2](https://sphinx-autodoc2.readthedocs.io/en/latest/).