### PR TITLE
[DOC] Sensor pipeline: physics-vs-hardware imperfections, return-space ring for delay + history

### DIFF
--- a/source/user_guide/advanced_topics/sensors/custom_sensors.md
+++ b/source/user_guide/advanced_topics/sensors/custom_sensors.md
@@ -12,7 +12,7 @@ To add a new sensor you contribute four artifacts:
 |---|---|---|
 | `<Name>` (an options class) | `genesis/options/sensors/<name>.py` (or your plugin package) | Public, user-facing dataclass that carries every per-sensor parameter. Inherits `SimpleSensorOptions` (or the appropriate mixin). Generic-parameterized with the sensor class as a forward reference. |
 | `<Name>SharedMetadata` | next to the sensor implementation | Per-sensor-class runtime state shared across every instance of this sensor in the scene. Inherits `SimpleSensorMetadata` (or `SharedSensorMetadata` for non-Simple sensors). |
-| `<Name>Sensor` | next to the sensor implementation | The sensor class itself. Inherits `SimpleSensor[<Name>, <Name>SharedMetadata]` and overrides `_get_return_format` (instance, shape), `_get_cache_dtype` (classmethod, dtype), `_update_raw_data`, plus optionally `_apply_transform`, `_post_process` (paired with `_get_intermediate_format` and/or `_get_intermediate_dtype`). |
+| `<Name>Sensor` | next to the sensor implementation | The sensor class itself. Inherits `SimpleSensor[<Name>, <Name>SharedMetadata]` and overrides `_get_return_format` (instance, shape), `_get_cache_dtype` (classmethod, dtype), `_update_raw_data`, plus optionally `_update_current_timestep_data`, `_apply_physics_imperfections`, `_apply_transform`, `_apply_hardware_imperfections`, `_post_process` (paired with `_get_intermediate_format` and/or `_get_intermediate_dtype`). |
 | (optional) a `NamedTuple` data class | next to the sensor implementation | If your sensor returns multiple tensors (e.g. IMU returns `lin_acc`, `ang_vel`, `mag`), declare a NamedTuple and pass it as the third type parameter: `SimpleSensor[<Name>, <Name>SharedMetadata, <Name>Data]`. |
 
 Genesis pairs an options class with its sensor class automatically as soon as both modules have been imported - the user only ever creates the options instance and passes it to `scene.add_sensor(...)`.
@@ -39,10 +39,10 @@ That gives you two supported placements:
 
 | Base | When to use |
 |---|---|
-| `SimpleSensor[OptionsT, MetadataT]` | Almost always. Per-step pipeline (raw data -> transform/filter -> hardware imperfections -> delay -> post-process). |
+| `SimpleSensor[OptionsT, MetadataT]` | Almost always. Per-step pipeline (raw -> physics imperfections -> transform -> hardware imperfections -> post-process -> delay sampling). |
 | `SimpleSensor[OptionsT, MetadataT, DataT]` | Same as above, but `read()` returns an instance of `DataT` (a `NamedTuple`) instead of a single tensor. IMU is the canonical example. |
 | `BaseCameraSensor[OptionsT]` | Camera-style sensors that render an RGB image lazily on `read()` (rasterizer, ray tracer, batched renderer, custom renderer). Inherits the lazy-render lifecycle, link-attachment with `pos/lookat/up`, and the `_post_process`/`_get_*` plumbing from `Sensor`. See [Camera-style sensors via BaseCameraSensor](#camera-style-sensors-via-basecamerasensor) below. |
-| `Sensor[OptionsT, MetadataT]` | Only when neither standard pipeline applies. Overriding at this level means implementing `_update_shared_cache` yourself, and (if your implementation does not use the measured ring) setting the class attribute `uses_measured_pipeline = False` to skip ring allocation. Also the right choice when you want **full kernel control** and need a single kernel pass to write both the ground-truth slice and the measured-timeline slot with internal noise (see [Kernel-internal physics noise](#kernel-internal-physics-noise) below). |
+| `Sensor[OptionsT, MetadataT]` | Only when neither standard pipeline applies. Overriding at this level means implementing `_update_shared_cache` yourself, and (if your implementation does not use the timeline rings) setting the class attribute `uses_ring_pipeline = False` to skip ring allocation. Also the right choice when you want **full kernel control** and need a single kernel pass to write both the ground-truth slice and the measured-timeline slot with internal noise (see [Kernel-internal physics noise](#kernel-internal-physics-noise) below). |
 
 For mixins, the convention is:
 
@@ -97,36 +97,53 @@ This is the only abstract hook of `SimpleSensor`. `_get_return_format` and `_get
 
 ### Optional overrides
 
-#### `_apply_transform(cls, shared_metadata, data, *, timeline=None)`
+#### `_apply_transform(cls, shared_metadata, data, *, timeline)`
 
-Apply a coordinate transform and/or a stateful temporal filter, in place, on `data` (a batch-first view `[B, cache_size, ...]`). Called twice per step: once on the ground-truth branch (`timeline=None`) and once on the measured branch (`timeline=<measured ring>`). The GT branch deliberately cannot run a filter - ground truth is the ideal signal with no hardware response.
+Apply a coordinate transform and/or a stateful response model, in place, on `data` (a batch-first view `[B, cache_size, ...]`). Called twice per step: once on the ground-truth branch with the GT timeline ring, once on the measured branch with the measured timeline ring. Both rings hold post-transform, **PRE-hardware-imperfection** values, so recurrence reads (`timeline.at(1)` and earlier) are always clean of hardware noise.
 
-- The coordinate-transform portion should be unconditional (executed on both branches).
-- The filter portion (e.g. exponential moving average, low-pass) must be gated on `if timeline is not None:` and read previous slots via `timeline.at(1)`, `timeline.at(2)`, etc. Filter-then-transform is not expressible by design - within a single override, write transform code first, then filter code.
-- **Aliasing note:** on the measured branch, `data is timeline.at(0, copy=False)` - they refer to the same memory. Use whichever reads more naturally and do not double-write.
+- The coordinate-transform portion runs unconditionally on both branches.
+- The response-model portion (e.g. thermal dissipation, exponential moving average, low-pass) reads previous slots via `timeline.at(1)`, `timeline.at(2)`, etc. The current write target is `data` (alias of `timeline.at(0)`); do not double-write.
+- **Aliasing note:** `data is timeline.at(0, copy=False)` - they refer to the same memory. Use whichever reads more naturally.
 
 ```python
 @classmethod
-def _apply_transform(cls, shared_metadata, data, *, timeline=None):
-    # transform branch: always runs
+def _apply_transform(cls, shared_metadata, data, *, timeline):
+    # Coordinate transform: always runs on both branches.
     data.copy_(transform_by_quat(data, shared_metadata.world_to_local_quat))
 
-    # filter branch: measured only
-    if timeline is not None and shared_metadata.has_filter:
-        prev = timeline.at(1)
-        data.mul_(1 - shared_metadata.alpha).add_(prev, alpha=shared_metadata.alpha)
+    # Stateful response model: reads the previous slot on the current branch's ring (one-pole low-pass with
+    # coefficient `alpha`, which the sensor's metadata subclass stored at build time).
+    prev = timeline.at(1)
+    data.mul_(1 - shared_metadata.alpha).add_(prev, alpha=shared_metadata.alpha)
 ```
 
-#### `_post_process(cls, shared_metadata, tensor) -> torch.Tensor`
+`_apply_transform` runs symmetrically on both branches with the same code, so any contribution applies to both ground truth and measurement. For a response-model effect that should only affect the measurement (e.g. a sensor-element bandwidth that the ideal GT signal should not see), put it in `_post_process` with the `is_measured=True` branch - that hook receives the per-class return-space ring as `timeline` and can read previous post-everything outputs for stateful recurrence (see below).
 
-Eager projection from intermediate space to return space. Override when the user-facing output type and/or shape differs from the pipeline-internal representation: bool threshold on `ContactSensor`, deadband + saturation on `ContactForceSensor`, etc. Returns a new tensor (the manager copies it into the return cache).
+#### `_post_process(cls, shared_metadata, tensor, *, timeline, is_measured) -> torch.Tensor`
 
-**Stateful is allowed.** Because the manager calls `_post_process` exactly once per simulation step, the override may carry per-call state in `metadata` (or in a dedicated cached attribute) and advance it on each call. This makes `_post_process` a natural home for software-level signal processing that the sensor offers on top of the raw measurement - complementary filter, Mahony filter, Kalman filter, an IMU quaternion estimator. Whether to put such estimators in the sensor's `_post_process` or in the user's controller is a design choice; both placements are valid. High-end IMUs that ship a fused orientation estimate are a real example of `_post_process`-shaped behavior.
+Projection from intermediate space to return space. Override when the user-facing output type and/or shape differs from the pipeline-internal representation: bool threshold on `ContactSensor`, deadband + saturation on `ContactForceSensor`, etc. Return the post-cast tensor; the manager writes it into slot 0 of the per-class return-space ring, and (on the measured branch) then delay-samples that ring into the user-visible return cache.
+
+Called once per branch per step. `tensor` is the full per-class intermediate cache in intermediate space (the current step's input). `timeline` is the per-class return-space ring; it is rotated AFTER this call returns, so inside the override `timeline.at(0)` is the previous step's post-output, `timeline.at(1)` is the step before that, and so on - stateful overrides (e.g. a sensor-element bandwidth filter on the measured branch) use these for recurrence. `is_measured` distinguishes branches (`True` on the measured call, `False` on the GT call) so an override can apply readout-stage contributions on only one side.
+
+Designed for cast / clamp / threshold / mask / deadband / simple reductions and (optionally) stateful HW responses that should not contaminate `_apply_transform` recurrence. Stateless overrides do not need to touch `timeline` or `is_measured` - the standard cast pattern stays one line:
 
 ```python
 @classmethod
-def _post_process(cls, shared_metadata, tensor):
+def _post_process(cls, shared_metadata, tensor, *, timeline, is_measured):
     return tensor > shared_metadata.thresholds
+```
+
+Example of a stateful, measured-only sensor-element bandwidth filter (one-pole low-pass on the post-output value,
+fed by the previous post-everything snapshot from the return-space ring):
+
+```python
+@classmethod
+def _post_process(cls, shared_metadata, tensor, *, timeline, is_measured):
+    out = tensor.clone()
+    if is_measured:
+        prev = timeline.at(0)  # ring rotates after this call; at(0) is the previous step's post-output.
+        out.mul_(1 - shared_metadata.alpha).add_(prev, alpha=shared_metadata.alpha)
+    return out
 ```
 
 If you override `_post_process` you **must** also override `_get_intermediate_format` and/or `_get_intermediate_dtype`. The pipeline enforces this at class-definition time:
@@ -143,7 +160,7 @@ See [the intermediate-vs-return separation section](sensor_pipeline.md#the-inter
 
 #### `_get_intermediate_format(self) -> tuple[...]`
 
-Instance method returning the shape of the **pipeline-internal** buffer (delay sampling, transform, filters, hardware imperfections all happen in this space). Defaults to `_get_return_format()`. Override together with `_post_process` whenever your projection changes shape, or as a no-op acknowledgement when only `_get_intermediate_dtype` would otherwise differ.
+Instance method returning the shape of the **pipeline-internal** buffer (transform, physics imperfections, hardware imperfections all happen in this space; `_post_process` projects out of it into return space). Defaults to `_get_return_format()`. Override together with `_post_process` whenever your projection changes shape, or as a no-op acknowledgement when only `_get_intermediate_dtype` would otherwise differ.
 
 ```python
 def _get_intermediate_format(self) -> tuple[int, ...]:
@@ -160,28 +177,47 @@ def _get_intermediate_dtype(cls) -> torch.dtype:
     return gs.tc_float  # float kernel output; bool projection in `_post_process`
 ```
 
-When `_get_intermediate_format` and `_get_intermediate_dtype` both default (and `_post_process` is identity, the common case), the manager allocates **one** buffer and aliases the return cache as a view of the intermediate cache. No extra memory, no copy.
+When `_get_intermediate_format` and `_get_intermediate_dtype` both default, `_post_process` is identity, **and** no sensor in the class declares `delay > 0` or `history_length > 0` (the common case for most no-op sensors), the manager allocates **one** buffer and aliases the return cache as a view of the intermediate cache - no extra memory, no copy. Any of those triggers - overriding `_post_process`, non-zero delay, non-zero history - causes the manager to allocate a separate per-class return cache and a per-class return-space ring to back delay sampling and history reads.
+
+#### `_apply_physics_imperfections(cls, shared_metadata, measured_slot_0)`
+
+Apply physics-level imperfections in place on the measured ring's current slot, **before** `_apply_transform`. Default: no-op. Override when the imperfection represents a property of the simulated phenomenon itself (e.g. genuine drift in the physical quantity being sensed) and therefore must propagate through the response model on subsequent steps. The contribution becomes part of the measured ring's slot 0 and feeds the next step's transform recurrence.
+
+This is the right home for "physics random walk" - drift that lives in the simulated world rather than in the sensor's readout stage. Anything that should *not* feed the response model (sensor electronics noise, ADC quantization) belongs in `_apply_hardware_imperfections` instead.
 
 #### `_apply_hardware_imperfections(cls, shared_metadata, measured_slot_0)`
 
-`SimpleSensor` already implements an opinionated interpretation of `noise`, `bias`, `random_walk`, and `resolution` as the perturbations the embedded sampler introduces at snapshot time. Override only when your sensor has a non-standard imperfection model - e.g. when noise must be added in a non-Cartesian space, or when the hardware-specific noise model is coupled to the raw signal in a way the generic implementation cannot express. In that case, you typically still call `super()._apply_hardware_imperfections(...)` for the standard pieces and add your custom term on top.
+`SimpleSensor` already implements an opinionated interpretation of `noise`, `bias`, `random_walk`, and `resolution` as the perturbations the embedded sampler introduces at the sensor output. Applied to the per-step measured working buffer **before** `_post_process` (and before the post-`_post_process` snapshot is frozen into the per-class return-space ring); the timeline ring is never written to, so `_apply_transform` recurrence stays clean. This is the **measured-only** stage of the pipeline; nothing here is mirrored on the GT branch.
 
-#### `_update_current_timestep_data(cls, shared_metadata, current_ground_truth_data_T, measured_data_timeline)`
+Designed for stateless per-step perturbations. Stateful HW responses (sensor-element bandwidth, signal-dependent gain with memory) belong in `_post_process`, which sees the per-class return-space ring and can read its previous slots via `timeline.at(0)` and earlier (the return ring rotates after `_post_process` returns).
 
-Default behavior: call `_update_raw_data` to produce the ground-truth value, then copy it into the measured ring's current slot. Override **only** when your sensor has **kernel-internal physical-response noise**, i.e. when the ground-truth signal and the measured signal must be produced by a single kernel pass with different paths inside. The default split (one kernel, then copy) is correct for every other case. See [Kernel-internal physics noise](#kernel-internal-physics-noise) below.
+Override when your sensor has a non-standard imperfection model. You typically still call `super()._apply_hardware_imperfections(...)` for the standard pieces and add your custom term on top:
 
-#### `uses_measured_pipeline` (class attribute, `ClassVar[bool]`)
+```python
+@classmethod
+def _apply_hardware_imperfections(cls, shared_metadata, measured_slot_0):
+    # Standard contributions (noise, bias, random_walk, resolution).
+    super()._apply_hardware_imperfections(shared_metadata, measured_slot_0)
+    # Custom: signal-dependent noise sampled fresh each step (multiplicative noise floor).
+    measured_slot_0 += torch.normal(0.0, shared_metadata.signal_noise_coeff) * measured_slot_0.abs()
+```
 
-Class-level capability flag declaring whether the class reads or writes the measured-timeline ring inside `_update_shared_cache`. The default is `True`, which is what `Sensor` exposes and `SimpleSensor` inherits unchanged: every sensor that uses the standard orchestrator needs the ring. Subclasses whose `_update_shared_cache` bypasses the ring entirely (built-in cameras handle rendering lazily on read and never touch `measured_data_timeline`) set this to `False` so the manager skips the allocation.
+#### `_update_current_timestep_data(cls, shared_metadata, current_ground_truth_data_T, ground_truth_data_timeline, measured_data_timeline)`
+
+Default behavior: call `_update_raw_data` to produce the ground-truth value into the contiguous `(cols, B)` kernel target `current_ground_truth_data_T`, then mirror it into the GT ring's slot 0 and the measured ring's slot 0. Override **only** when your sensor has **kernel-internal physical-response noise**, i.e. when the ground-truth signal and the measured signal must be produced by a single kernel pass with different paths inside. The default split (one kernel, then mirror) is correct for every other case. See [Kernel-internal physics noise](#kernel-internal-physics-noise) below.
+
+#### `uses_ring_pipeline` (class attribute, `ClassVar[bool]`)
+
+Class-level capability flag declaring whether the class participates in the ring-based per-step pipeline inside `_update_shared_cache`. The default is `True`, which is what `Sensor` exposes and `SimpleSensor` inherits unchanged: every sensor that uses the standard orchestrator needs the GT and measured timeline rings. Subclasses whose `_update_shared_cache` bypasses the rings entirely (built-in cameras handle rendering lazily on read and never touch either timeline) set this to `False` so the manager skips the paired allocation.
 
 Set it on the class itself, not on the instance - the manager reads it once at scene-build time to decide ring allocation per sensor class. Changing it after build has no effect because allocation is already done.
 
 ```python
 class MyCustomSensor(Sensor[MyOptions, MyMetadata]):
-    uses_measured_pipeline: ClassVar[bool] = False  # only if you implement `_update_shared_cache` from scratch
+    uses_ring_pipeline: ClassVar[bool] = False  # only if you implement `_update_shared_cache` from scratch
 ```
 
-The runtime gating of imperfection contributions (`has_any_noise`, `has_any_bias`, etc.) is a separate concern handled inside `_apply_hardware_imperfections`; those flags are updated by the `set_*` setters and decide per-step which contributions cost any work. Ring allocation is binary: either the class uses the ring or it doesn't.
+The runtime gating of imperfection contributions (`has_any_noise`, `has_any_bias`, etc.) is a separate concern handled inside `_apply_hardware_imperfections`; those flags are updated by the `set_*` setters and decide per-step which contributions cost any work. Ring allocation is binary: either the class uses the rings or it doesn't.
 
 ## Kernel-internal physics noise
 
@@ -189,11 +225,8 @@ Some sensors have noise that is **intrinsic to the physics computation** - a sin
 
 Two supported routes:
 
-1. **Override `_update_current_timestep_data` on `SimpleSensor`.** Your kernel writes `current_ground_truth_data_T` (the GT slice, `(cols, B)`) **and** `measured_data_timeline.at(0, copy=False)` (the measured slot 0, `(B, cols)`) in one pass. The rest of the SimpleSensor pipeline (`_apply_transform` on both branches, `_apply_hardware_imperfections`, delay sampling, eager `_post_process`) still runs on top. Recommended when you also want any of the standard pipeline pieces (imperfection parameters, delay/jitter, `_post_process` projection).
-2. **Derive from `Sensor` directly and override `_update_shared_cache`.** Skips the SimpleSensor chain entirely.
-   The override receives `(metadata, gt_T, measured_timeline, intermediate_cache, return_cache)` and is
-   responsible for populating them. Use this when the sensor needs a fundamentally non-standard pipeline (e.g.
-   cameras and renderers).
+1. **Override `_update_current_timestep_data` on `SimpleSensor`.** Your kernel writes `current_ground_truth_data_T` (the contiguous `(cols, B)` GT slice) **and** `measured_data_timeline.at(0, copy=False)` (the measured slot 0, `(B, cols)`) in one pass, and (when allocated) `ground_truth_data_timeline.at(0, copy=False)` (the GT slot 0). The rest of the SimpleSensor pipeline (`_apply_physics_imperfections`, `_apply_transform` on both branches, delay sampling, `_apply_hardware_imperfections`, eager `_post_process`) still runs on top. Recommended when you also want any of the standard pipeline pieces (imperfection parameters, delay/jitter, `_post_process` projection).
+2. **Derive from `Sensor` directly and override `_update_shared_cache`.** Skips the SimpleSensor chain entirely. The override receives `(metadata, gt_T, gt_timeline, measured_timeline, intermediate_cache, return_cache)` and is responsible for populating them. Use this when the sensor needs a fundamentally non-standard pipeline (e.g. cameras and renderers).
 
 ## Camera-style sensors via `BaseCameraSensor`
 
@@ -204,7 +237,7 @@ Two supported routes:
 - Lazy render-on-read with per-step caching: multiple `read()` calls in the same simulation step share a single render. No need to implement `_update_shared_cache`.
 - Link attachment with `pos`/`lookat`/`up` (or an explicit `offset_T`): the camera follows a `RigidLink` each frame and hands you the world-space transform to apply to your renderer.
 - An RGB output of shape `((h, w, 3),)` and dtype `torch.uint8` declared from `options.res`, plus a `read(envs_idx=...) -> CameraData` returning a `NamedTuple(rgb=...)` (with the leading batch dim dropped when `n_envs == 0`).
-- The class is opted out of the measured-timeline ring, and `__init__` rejects `delay > 0`, `jitter > 0`, and `history_length > 0` so users cannot silently request features that this sensor type cannot honor.
+- The class is opted out of the ring pipeline (`uses_ring_pipeline = False`), and `__init__` rejects `delay > 0`, `jitter > 0`, and `history_length > 0` so users cannot silently request features that this sensor type cannot honor.
 
 **What you must implement**
 
@@ -355,7 +388,7 @@ Every concrete sensor must implement `_get_return_format` (instance) and `_get_c
 | `IMUSensor` | yes | - | yes (body-frame rotation; no filter) | identity |
 | `ProximitySensor` | yes | - | - | identity |
 | `RaycasterSensor` / `DepthCameraSensor` | yes | - | - | identity |
-| `TemperatureGridSensor` | yes (raw temperature kernel) | - | yes (RC filter; `if timeline is not None: data.copy_(alpha * data + (1 - alpha) * timeline.at(1))`) | identity |
+| `TemperatureGridSensor` | yes (raw temperature kernel) | - | yes (RC filter that reads `timeline.at(1)` on both branches; recurrence stays clean because hardware imperfections never reach the ring) | identity |
 | `ElastomerDisplacementSensor` | yes | - | - | identity |
 | Camera (any `*CameraSensor`) | - | - | - | identity. Derives from `BaseCameraSensor`; see [Camera-style sensors via BaseCameraSensor](#camera-style-sensors-via-basecamerasensor). |
 

--- a/source/user_guide/advanced_topics/sensors/sensor_pipeline.md
+++ b/source/user_guide/advanced_topics/sensors/sensor_pipeline.md
@@ -17,12 +17,13 @@ sensor hardware ─► (analog wire, ADC, electronics noise, sensor's own bandwi
 
 The robot's `read()` is a **memory lookup**. It does not trigger sensor acquisition. The sensor was sampled asynchronously, possibly milliseconds ago, by an embedded process running at its own rate. Two `read()` calls in the same control-loop timestep return the **same value** because no new snapshot has been written between them. The reading is stable for the duration of one sampling period.
 
-This shapes every design decision in the pipeline:
+This shapes every design decision in the pipeline. Imperfections split into two layers depending on where the imperfection physically lives:
 
-- **Noise, drift, quantization, bias** are introduced by the embedded sampling layer **at snapshot time**. Once a digitized value sits in shared memory, the noise is baked in - reading the same cell later returns the same noisy value.
-- **Delay (and its jitter)** is the staleness of the snapshot relative to "now". A sensor with `delay = D` (plus a random `jitter` drawn each step) means: at control-loop time `t`, the snapshot the robot reads was captured at time `t - D - jitter_t`. The snapshot was produced *with its imperfection state at the time of capture*; reading it later returns those imperfections unchanged. `delay` and `jitter` always travel together - jitter cannot exceed delay, and any non-zero jitter requires interpolation between adjacent ring slots.
+- **Physics-level imperfections** are properties of the physical phenomenon being sensed (e.g. genuine drift in the simulated process, low-pass coupling in a thermistor's surroundings). They accumulate through the sensor's response model and therefore must propagate through transform recurrence. They are written into the timeline ring and read by `_apply_transform` on the following step.
+- **Hardware-level imperfections** are properties of the sensor's own readout stage (electronic noise, ADC quantization, sensor-output drift). They are applied at the sensor-output stage, on the per-step working buffer - never on the timeline ring. The post-`_post_process` snapshot is frozen into the return-space ring slot 0, so each captured snapshot carries the imperfection state that was sampled at that step. Transform recurrence reads only the timeline ring (clean of hardware noise), so a stateful response model (thermal dissipation, low-pass filter) is never amplified by hardware noise of the previous step.
+- **Delay (and its jitter)** is the staleness of the snapshot relative to "now". A sensor with `delay = D` (plus a random `jitter` drawn each step) means: at control-loop time `t`, the robot's read returns the post-everything value captured at time `t - D - jitter_t` (response-model output + the hardware imperfection sample that was drawn at that step). `delay` and `jitter` always travel together - jitter cannot exceed delay. Sampling is zero-order-hold (ZOH) by default, which is dtype-safe for arbitrary return types (bool, uint8, quantized float) and is the right semantics for a snapshot that is meant to look "frozen at capture". Sensors whose return space is a continuous-valued float and that benefit from a smoother sampling rule can override `_apply_delay`.
 - **Reads are idempotent within a step.** If a design implies they aren't, the abstraction is broken.
-- **History reads** (`sensor.read(history_length=N)`) return the `N` most recent snapshots, each with the imperfection state that was present when it was produced.
+- **History reads** (`sensor.read(history_length=N)`) return the `N` most recent **final** measurements, i.e. snapshots of the post-everything value (post-delay, post-hardware, post-cast) at each past step.
 
 ## Class hierarchy
 
@@ -42,7 +43,7 @@ Camera (RasterizerCameraSensor, RaytracerCameraSensor, BatchRendererCameraSensor
 - it has its own rendering path and does not use the SimpleSensor pipeline.
 ```
 
-`Sensor` is the minimal customization contract - a single abstract per-step compute method (`_update_shared_cache`), four spec accessors (`_get_return_format` / `_get_intermediate_format` as instance methods for shape; `_get_cache_dtype` / `_get_intermediate_dtype` as classmethods for dtype), a `_post_process` projection (identity by default), and a class-level capability flag (`uses_measured_pipeline: ClassVar[bool] = True`) telling the manager whether to allocate the measured-timeline ring for the class. `SimpleSensor` builds the standard pipeline on top, exposing four override hooks (`_update_raw_data`, `_update_current_timestep_data`, `_apply_transform`, `_apply_hardware_imperfections`) that concrete sensors override as needed. Signatures, contracts, and worked examples are in [Implementing Custom Sensors](custom_sensors.md). This page focuses on what those hooks *do* at runtime - the order in which they fire and the buffers they read and write.
+`Sensor` is the minimal customization contract - a single abstract per-step compute method (`_update_shared_cache`), four spec accessors (`_get_return_format` / `_get_intermediate_format` as instance methods for shape; `_get_cache_dtype` / `_get_intermediate_dtype` as classmethods for dtype), a `_post_process` projection (identity by default), and a class-level capability flag (`uses_ring_pipeline: ClassVar[bool] = True`) telling the manager whether to allocate the per-step timeline rings (GT + measured) for the class. `SimpleSensor` builds the standard pipeline on top, exposing five override hooks (`_update_raw_data`, `_update_current_timestep_data`, `_apply_physics_imperfections`, `_apply_transform`, `_apply_hardware_imperfections`) that concrete sensors override as needed. Signatures, contracts, and worked examples are in [Implementing Custom Sensors](custom_sensors.md). This page focuses on what those hooks *do* at runtime - the order in which they fire and the buffers they read and write.
 
 ## Per-step pipeline
 
@@ -50,66 +51,85 @@ Camera (RasterizerCameraSensor, RaytracerCameraSensor, BatchRendererCameraSensor
 [per-step, driven by SimpleSensor's orchestrator]
 
   _update_current_timestep_data
+            │  raw -> GT intermediate cache  (kernel target, contiguous (cols, B))
+            │  mirrored to GT timeline ring slot 0  +  measured timeline ring slot 0
             │
-            ├──► [GT branch]       ──► _apply_transform(data, timeline=None)
-            │                                     │
-            │                                     ▼
-            │                          newest GT slot in the timeline ring
-            │                          (current GT in intermediate space)
-            │                                     │
-            │                                     ▼
-            │                          _post_process(GT intermediate)
-            │                          (mirrored on the GT side so read_ground_truth()
-            │                           is symmetric with read())
-            │                                     │
-            │                                     ▼
-            │                          per-class GT return cache (return shape/dtype)
+            ├──► [GT branch]
+            │       │
+            │       ▼
+            │   _apply_transform(GT slot 0, timeline=GT timeline ring)
+            │       │  (reads previous slots for stateful response models)
+            │       ▼
+            │   GT slot 0 is the post-transform value; copied back into GT
+            │   intermediate cache
+            │       │
+            │       ▼
+            │   _post_process(GT intermediate, timeline=GT return ring, is_measured=False)
+            │       │  (cast / clamp / mask, optionally stateful via return ring)
+            │       ▼
+            │   write to GT return-space ring slot 0  (post-everything snapshot)
+            │       │
+            │       ▼
+            │   read GT return ring at(0) -> per-class GT return cache (GT has no delay)
             │
-            └──► [measured branch]  ──► _apply_transform(data, timeline=ring)
-                                                 │ (transform on both branches; filter portion
-                                                 │  gated by `if timeline is not None` reads earlier slots)
-                                                 ▼
-                                       _apply_hardware_imperfections(current snapshot)
-                                                 │ (noise/bias/random_walk/resolution baked in
-                                                 │  at snapshot time - PRE-delay)
-                                                 ▼
-                                       newest measured slot in the timeline ring
-                                       (current snapshot in intermediate space)
-                                                 │
-                                                 ▼
-                                       delay sampling: read stale slot at (delay + jitter) steps back
-                                       (per-env offsets; reads STALE snapshots with their
-                                        original imperfection state)
-                                                 │
-                                                 ▼
-                                       _post_process(intermediate cache)
-                                       (eager, once per step; per-class classmethod)
-                                                 │
-                                                 ▼
-                                       per-class measured return cache (return shape/dtype)
-
-[per-step refresh, only for sensor classes with overridden `_post_process` AND `history_length > 0`]
-
-  current step's eager `_post_process` result is written to slot 0 of a per-class return-space ring
-  (correct for stateful `_post_process`: each historical slot keeps the projection state at its capture time)
+            └──► [measured branch]
+                    │
+                    ▼
+                _apply_physics_imperfections(measured slot 0)
+                    │  (default no-op; physics-level imperfections that should
+                    │   propagate through transform recurrence)
+                    ▼
+                _apply_transform(measured slot 0, timeline=measured timeline ring)
+                    │  (recurrence reads clean pre-hardware previous slots)
+                    ▼
+                measured slot 0 holds post-physics, post-transform value
+                    │
+                    ▼
+                copy measured ring slot 0 -> per-dtype intermediate cache
+                (the per-step working buffer)
+                    │
+                    ▼
+                _apply_hardware_imperfections(intermediate cache)
+                    │  (stateless noise/bias/random_walk/resolution applied on the
+                    │   per-step working buffer; never written into the timeline
+                    │   ring, so transform recurrence stays clean)
+                    ▼
+                _post_process(intermediate cache, timeline=measured return ring, is_measured=True)
+                    │  (cast / clamp / mask; stateful HW responses such as a
+                    │   sensor-element bandwidth filter live here, reading
+                    │   `timeline.at(0)` for the previous post-everything output -
+                    │   the return ring rotates after this call returns)
+                    ▼
+                write to measured return-space ring slot 0  (post-everything snapshot,
+                with this step's hardware noise frozen in)
+                    │
+                    ▼
+                delay sampling: read stale slot at (delay + jitter) steps back
+                from the measured return ring -> per-class measured return cache
+                    │  (per-env offsets; each delayed slot carries its own frozen
+                    │   imperfection state from the step at which it was captured)
+                    ▼
+                user-visible read value
 
 [read paths - idempotent within a step]
 
-  Sensor.read()                          ─► view into latest snapshot for this sensor
-  Sensor.read_ground_truth()             ─► same, ground-truth side
-  Sensor.read(history_length=N)          ─► fresh tensor with the last N snapshots, gathered from the return-space
-                                            ring (overridden `_post_process`) or the intermediate ring (identity)
-  SensorManager.read_sensors()           ─► fresh tensor per class; per-class return cache (no history) or ring
-                                            gather (history).
+  Sensor.read()                          ─► view of the measured return cache for this sensor
+                                            (post-delay-sample when delay > 0; otherwise the
+                                            current step's post-everything value)
+  Sensor.read_ground_truth()             ─► same, ground-truth side (no delay)
+  Sensor.read(history_length=N)          ─► fresh tensor with the last N snapshots,
+                                            gathered from the per-class return-space ring
+  SensorManager.read_sensors()           ─► fresh tensor per class; per-class return cache
+                                            (no history) or per-class return-space ring (history).
 ```
 
 ### The intermediate-vs-return separation
 
-The pipeline operates in **intermediate space** throughout (delay sampling, transform, filters, hardware imperfections). Casting (bool threshold, clamp, mask, deadband) lives in `_post_process`, which is applied **eagerly** once per step at the end of the orchestrator. This populates a per-class **return cache** in the return space (shape declared by `_get_return_format`, dtype by `_get_cache_dtype`).
+The pipeline operates in **intermediate space** through every stage up to and including `_apply_hardware_imperfections` (transform, physics imperfections, hardware imperfections all read and write intermediate-space values). Casting (bool threshold, clamp, mask, deadband) lives in `_post_process`, which projects intermediate space to return space. The return-space ring stores those projected snapshots; delay sampling then reads previous slots of that ring and writes them into the per-class return cache (shape declared by `_get_return_format`, dtype by `_get_cache_dtype`).
 
-The separation is **structural, not aesthetic**. `_apply_transform(timeline=...)` lets filter overrides read previous slots of the timeline ring (e.g. `timeline.at(1)` for the previous frame); those slots must be in the **same data space** as the `data` argument the override receives, otherwise the filter mixes apples and oranges and silently produces wrong output. So the timeline ring holds intermediate-space values; the return cache is a separate buffer in the return space.
+The separation is **structural, not aesthetic**. `_apply_transform(timeline=...)` lets filter overrides read previous slots of the timeline ring (e.g. `timeline.at(1)` for the previous frame); those slots must be in the **same data space** as the `data` argument the override receives, otherwise the filter mixes apples and oranges and silently produces wrong output. So the timeline ring holds intermediate-space values; the return cache and the return-space ring are in return space.
 
-When `_post_process` is identity, the manager allocates a single buffer and aliases `return_cache` as a view of the intermediate slice - no extra storage. When `_post_process` is overridden (ContactSensor: float to bool; ContactForceSensor: clamp + masked_fill), the return cache is a distinct buffer. The author signals this distinction by overriding `_get_intermediate_format` and/or `_get_intermediate_dtype` (a no-op override returning the return-space value is acceptable when shape and dtype coincide).
+When `_post_process` is identity AND no delay/history is configured, the manager allocates a single buffer and aliases `return_cache` as a view of the intermediate slice - no extra storage. When `_post_process` is overridden (ContactSensor: float to bool; ContactForceSensor: clamp + masked_fill), the return cache is a distinct buffer fed by the return-space ring. The author signals the intermediate / return distinction by overriding `_get_intermediate_format` and/or `_get_intermediate_dtype` (a no-op override returning the return-space value is acceptable when shape and dtype coincide).
 
 ### Why shape is per-instance and dtype is class-uniform
 
@@ -121,27 +141,27 @@ When `_post_process` is identity, the manager allocates a single buffer and alia
 
 Three reasons:
 
-1. **Stateful post-processing is well-defined.** Because the manager calls `_post_process` exactly once per simulation step, the override may carry per-call state and advance it deterministically. This makes `_post_process` a natural home for software-level signal processing layered on top of the raw measurement - complementary filter, Mahony filter, Kalman filter, IMU quaternion estimator. A lazy (read-time) placement would re-invoke the projection N times per step for N consumers (controller + logger + visualization), advancing any internal state by N instead of 1 - corrupting the estimator's time series.
+1. **Deterministic call count.** The manager calls `_post_process` a fixed number of times per simulation step (once per branch), independent of how many consumers (controller + logger + visualization) `read()` the sensor. A lazy (read-time) placement would re-invoke the projection N times per step for N consumers, which is wasteful and breaks any stateful override.
 2. **Real per-class return storage.** Without eager projection, the per-class return cache wouldn't exist and `_post_process` overrides would have to allocate fresh tensors at every read. Eager placement means the manager owns a real per-class buffer of post-processed values that every read path (single sensor or bulk class read) gathers from.
 3. **Amortized cost.** A typical control loop reads each sensor once per step from the controller, again from a logger, again from visualization. Eager projection runs the post-process once per step regardless of read fan-out. Lazy projection would re-run it per consumer.
 
 ## Storage scopes and the per-step loop
 
-The manager owns all storage. Conceptually there are three scopes:
+The manager owns all storage. Conceptually there are four scopes:
 
-- **Per-dtype intermediate storage** - one buffer per data type used by sensors with that dtype, holding pipeline-internal values that hooks like `_apply_transform` read and write. A contiguous slice within this buffer belongs to each sensor class.
-- **Per-class return storage** - one buffer per sensor class, in the return space declared by `_get_return_format` / `_get_cache_dtype`. When `_post_process` is the identity default the return view aliases into the intermediate slice (no extra memory); when `_post_process` is overridden it is a distinct buffer that the eager projection writes into.
-- **Per-dtype timeline ring** - circular buffer of recent intermediate-space snapshots. The ground-truth ring is sized by the deepest `delay` and `history_length` requirement among sensors of that dtype; with all defaults it collapses to a single slot. The measured ring is allocated whenever any sensor class declares `uses_measured_pipeline = True` (the default; only sensors that bypass the standard orchestrator opt out). The two sides share their rotation index so a single rotation step advances both.
-- **Per-class return-space ring** (rare) - allocated only for classes whose `_post_process` is overridden AND that have `history_length > 0`. Each step the eager `_post_process` snapshot is written to slot 0 of this ring, so history reads can pull post-processed values directly. For sensors with identity `_post_process` (most of them) the intermediate ring already holds return-space values, and no extra ring is needed.
+- **Per-dtype intermediate storage** - one buffer per data type used by sensors with that dtype, holding pipeline-internal values that hooks like `_apply_transform` and `_apply_hardware_imperfections` read and write. A contiguous slice within this buffer belongs to each sensor class.
+- **Per-class return storage** - one buffer per sensor class in the return space declared by `_get_return_format` / `_get_cache_dtype`. When no per-class return-space ring is needed (identity `_post_process`, no delay, no history) the return cache is a zero-copy alias-view of the intermediate cache; otherwise it is a distinct buffer that the orchestrator fills from the return-space ring (via delay sampling on the measured side, slot-0 read on the GT side).
+- **Per-dtype timeline rings** (GT + measured) - paired circular buffers in intermediate space, holding post-transform, **PRE-hardware-imperfection** snapshots. Allocated together when any sensor class in the dtype declares `uses_ring_pipeline = True` (the default). Sized `max(2, max_history)` - two slots are enough for the staging buffer + one-step recurrence used by `_apply_transform`, and growing to `max_history` when any sensor in the dtype requests history lets multi-tap stateful filters inside `_apply_transform` read deeper without keeping their own state. The two share their rotation index so a single rotation advances both.
+- **Per-class return-space rings** (GT + measured) - paired circular buffers in return space (post-`_post_process`, pre-delay-sample). Allocated whenever any sensor in the class has `delay > 0` OR `history_length > 0` OR the class overrides `_post_process`. Each step the post-everything snapshot is written to slot 0; delay sampling and history reads both source from here. Sized `max(max_delay+1, max_history, 2_if_post_process_overridden)`. Each delayed slot carries its own frozen imperfection state from the step at which it was captured. GT and measured rings share their rotation index.
 
 Per simulation step the manager:
 
-1. Rotates the timeline rings that exist, freeing the oldest slot to write the new snapshot.
-2. For each sensor class, invokes `_update_shared_cache` once, passing the per-class slices of the intermediate cache, the measured timeline ring (or `None` if the class opted out), and the per-class return cache. The hook is responsible for producing the ground-truth signal and the measured snapshot in those buffers.
-3. Mirrors the eager `_post_process` projection on the ground-truth side so that `read_ground_truth()` is symmetric with `read()`.
-4. For sensor classes whose `_post_process` is overridden AND that declare `history_length > 0`, writes the freshly post-processed ground-truth and measured snapshots into the per-class return-space ring. Identity-projection classes need no extra ring (the intermediate ring is already in return space).
+1. Rotates the per-dtype timeline ring pair and the per-class return-space ring pair, freeing the oldest slot for the new snapshot.
+2. For each sensor class, invokes `_update_shared_cache` once, passing the per-class slices of the intermediate cache, both timeline rings (GT + measured; `None` for classes that opted out), and the per-class return cache. The hook produces the ground-truth signal in the GT intermediate cache and the measured snapshot (post-physics, post-transform, post-hardware-imperfections) in the per-step working buffer.
+3. Runs `_post_process` on both branches and writes the result to slot 0 of the per-class return-space ring pair. Skipped when no return-space ring is allocated (alias-view propagates the per-step write automatically).
+4. Reads slot 0 of the GT return ring into the GT return cache; per-sensor delay-samples the measured return ring into the measured return cache. For sensors with `delay = 0` and no jitter this is just slot-0 reads.
 
-`read_sensors(envs_idx=...)` always returns a fresh tensor per class, independent of internal sensor storage. Non-history reads gather the current snapshot from the per-class return cache; history reads gather the last `N` snapshots from the appropriate ring. The caller is free to mutate the result.
+`read_sensors(envs_idx=...)` always returns a fresh tensor per class, independent of internal sensor storage. Non-history reads gather the current snapshot from the per-class return cache; history reads gather the last `N` snapshots from the appropriate return-space ring. The caller is free to mutate the result.
 
 ## Options and their pipeline semantics
 
@@ -149,19 +169,18 @@ Two options classes feed the pipeline. `SensorOptions` carries the time-related 
 
 | Option | Default | Where it acts |
 |---|---|---|
-| `delay` | 0.0 | Sets the read offset into the measured ring (seconds, snapshot age). |
+| `delay` | 0.0 | Read offset into the measured return-space ring (seconds, snapshot age). A delayed read returns the post-everything value that was produced D steps ago, with the imperfections frozen at that step. |
 | `jitter` | 0.0 | Random additive delay per env, sampled `Uniform[0, jitter)` each step. Must be <= `delay`. |
-| `interpolate` | False | Linear interpolation between adjacent ring slots for fractional delays. Required when `jitter > 0`. |
-| `history_length` | 0 | When `> 0`, sensor `read()` returns the last `N` snapshots stacked along a new history axis, shape `(B, N, *return_shape)`; index 0 is the current step. |
-| `noise` | 0.0 | Std-dev of zero-mean Gaussian, added to the snapshot at PRE-delay snapshot time. Independent each step. |
-| `bias` | 0.0 | Constant offset added at snapshot time. |
-| `random_walk` | 0.0 | Std-dev of the random-walk step. The drift accumulator advances each step and is added at production time, so a delayed read returns the drift state from when the snapshot was captured. |
-| `resolution` | 0.0 | Quantization step. Snapshot values are rounded to multiples of this. |
+| `history_length` | 0 | When `> 0`, sensor `read()` returns the last `N` final measurements stacked along a new history axis, shape `(B, N, *return_shape)`; index 0 is the current step. |
+| `noise` | 0.0 | Std-dev of zero-mean Gaussian, sampled once per step in `_apply_hardware_imperfections` and frozen into the return-space ring slot at capture time. Independent each step. |
+| `bias` | 0.0 | Constant offset added at the sensor output stage. |
+| `random_walk` | 0.0 | Std-dev of the random-walk step. The drift accumulator advances each step and is added to the output, then frozen into the return-space ring slot at capture time, so a delayed read sees the drift the sensor had at the moment it was captured. |
+| `resolution` | 0.0 | Quantization step. Output values are rounded to multiples of this. |
 
-`noise`, `bias`, `random_walk`, `resolution` are deliberately generic - they're imperfection *parameters*. `SimpleSensor._apply_hardware_imperfections` is the one that picks the "embedded sampler" interpretation laid out above. A direct `Sensor` subclass could interpret them differently or ignore them entirely (Camera does).
+`noise`, `bias`, `random_walk`, `resolution` are deliberately generic - they're imperfection *parameters*. `SimpleSensor._apply_hardware_imperfections` picks the "embedded sampler" interpretation laid out above (sensor-output stage). A direct `Sensor` subclass could interpret them differently or ignore them entirely (Camera does). Imperfections that need to propagate through the response model (e.g. genuine drift in the physical phenomenon being sensed) belong in an `_apply_physics_imperfections` override instead - that hook runs **before** `_apply_transform` so its contribution feeds the next step's recurrence.
 
-### Why noise lives at snapshot time, not read time
+### Why imperfections are baked in at capture time
 
-If noise were applied at read time (e.g. fresh per `read()` call), two `read()` calls in the same control-loop timestep would return different values. That breaks the embedded-sampler abstraction: once a digitized value is in shared memory, the noise is baked in - the user code that reads it doesn't re-sample. The pipeline places noise where the embedded sampler actually introduces it.
+The robot's `read()` is a memory lookup. Once a digitized value sits in the ring, the noise is frozen - reading the same slot later returns the same noisy value. This is what makes two `read()` calls within the same control-loop timestep return identical results, and what gives a delayed read the imperfection state the sensor had at the time of capture (random-walk drift from 100 ms ago is the drift the sensor actually had 100 ms ago, not the drift it has now).
 
-This also makes `random_walk` (drift) physically correct: a snapshot captured 100 ms ago shows the drift state the sensor had 100 ms ago, not the drift the sensor has now.
+Placing per-step hardware imperfections on the working buffer (not on the timeline ring) is what protects transform recurrence: a stateful response model (thermal dissipation, low-pass filter) reads previous slots of the timeline ring, which are clean of hardware noise. The return-space ring stores the post-everything snapshot AFTER `_apply_hardware_imperfections` has run for the current step, which is what later delay sampling reads.


### PR DESCRIPTION
## Summary

Rewrites \`sensor_pipeline.md\` and \`custom_sensors.md\` to match the new sensor pipeline implementation that lands alongside this PR in \`genesis-world\`.

### Pipeline-level changes

- New \`_apply_physics_imperfections\` hook. Lives between raw and \`_apply_transform\` on the measured branch only; in-ring contribution that propagates through transform recurrence.
- \`_apply_hardware_imperfections\` no longer writes to the timeline ring. It mutates a per-step working buffer (the intermediate cache) before \`_post_process\`, so transform recurrence stays clean of hardware noise.
- Two-layer ring storage:
  - **Per-dtype timeline rings** (GT + measured): \`_apply_transform\` recurrence source, sized \`max(2, max_history)\`.
  - **Per-class return-space rings**: post-\`_post_process\` snapshots; source for delay sampling, history reads, and stateful \`_post_process\` overrides. Allocated when \`delay > 0\` OR \`history_length > 0\` OR \`_post_process\` is overridden.
- Delay sampling moves to **after** \`_post_process\`, reads from the return-space ring. Embedded-sampler semantics: each delayed slot carries its own frozen imperfection state.
- Default delay is **ZOH** (zero-order hold). Dropped the \`interpolate\` option entirely - it broke for non-float return dtypes (bool, uint8). Sensors that want a smoother sampling rule override the new \`_apply_delay\` classmethod.
- \`_post_process\` signature gains \`timeline\` and \`is_measured\`. The return-space ring rotates **after** \`_post_process\` returns, so \`timeline.at(0)\` inside the override is the previous step's post-output (no stale-slot footgun).
- Rename: \`uses_measured_pipeline\` -> \`uses_ring_pipeline\` (the flag now gates both GT and measured timeline rings).

### Doc deliverables

- \`sensor_pipeline.md\`: rewrote the pipeline diagram; updated storage scopes (four buffer layers), the imperfection-options semantics table (drops \`interpolate\`, updates the embedded-sampler framing), the "Why imperfections are baked in at capture time" subsection.
- \`custom_sensors.md\`: updated \`_post_process\`, \`_apply_physics_imperfections\`, \`_apply_hardware_imperfections\`, \`_update_current_timestep_data\`, \`uses_ring_pipeline\` signatures. Added worked example for a stateful measured-only bandwidth filter in \`_post_process\`. Removed advice that no longer applies (gating \`_apply_transform\` on branch identity).