### PR TITLE
[DOC] Drop return_cache from _update_shared_cache signature in pipeline docs

### DIFF
--- a/source/user_guide/advanced_topics/sensors/custom_sensors.md
+++ b/source/user_guide/advanced_topics/sensors/custom_sensors.md
@@ -226,7 +226,7 @@ Some sensors have noise that is **intrinsic to the physics computation** - a sin
 Two supported routes:
 
 1. **Override `_update_current_timestep_data` on `SimpleSensor`.** Your kernel writes `current_ground_truth_data_T` (the contiguous `(cols, B)` GT slice) **and** `measured_data_timeline.at(0, copy=False)` (the measured slot 0, `(B, cols)`) in one pass, and (when allocated) `ground_truth_data_timeline.at(0, copy=False)` (the GT slot 0). The rest of the SimpleSensor pipeline (`_apply_physics_imperfections`, `_apply_transform` on both branches, delay sampling, `_apply_hardware_imperfections`, eager `_post_process`) still runs on top. Recommended when you also want any of the standard pipeline pieces (imperfection parameters, delay/jitter, `_post_process` projection).
-2. **Derive from `Sensor` directly and override `_update_shared_cache`.** Skips the SimpleSensor chain entirely. The override receives `(metadata, gt_T, gt_timeline, measured_timeline, intermediate_cache, return_cache)` and is responsible for populating them. Use this when the sensor needs a fundamentally non-standard pipeline (e.g. cameras and renderers).
+2. **Derive from `Sensor` directly and override `_update_shared_cache`.** Skips the SimpleSensor chain entirely. The override receives `(metadata, gt_T, gt_timeline, measured_timeline, intermediate_cache)` and is responsible for populating them. The manager handles `_post_process` projection, return-space ring writes, and delay sampling after the hook returns. Use this when the sensor needs a fundamentally non-standard pipeline (e.g. cameras and renderers).
 
 ## Camera-style sensors via `BaseCameraSensor`
 

--- a/source/user_guide/advanced_topics/sensors/sensor_pipeline.md
+++ b/source/user_guide/advanced_topics/sensors/sensor_pipeline.md
@@ -129,7 +129,7 @@ The pipeline operates in **intermediate space** through every stage up to and in
 
 The separation is **structural, not aesthetic**. `_apply_transform(timeline=...)` lets filter overrides read previous slots of the timeline ring (e.g. `timeline.at(1)` for the previous frame); those slots must be in the **same data space** as the `data` argument the override receives, otherwise the filter mixes apples and oranges and silently produces wrong output. So the timeline ring holds intermediate-space values; the return cache and the return-space ring are in return space.
 
-When `_post_process` is identity AND no delay/history is configured, the manager allocates a single buffer and aliases `return_cache` as a view of the intermediate slice - no extra storage. When `_post_process` is overridden (ContactSensor: float to bool; ContactForceSensor: clamp + masked_fill), the return cache is a distinct buffer fed by the return-space ring. The author signals the intermediate / return distinction by overriding `_get_intermediate_format` and/or `_get_intermediate_dtype` (a no-op override returning the return-space value is acceptable when shape and dtype coincide).
+When `_post_process` is identity AND no delay/history is configured, the manager allocates a single buffer and aliases the per-class return cache as a view of the intermediate slice - no extra storage. When `_post_process` is overridden (ContactSensor: float to bool; ContactForceSensor: clamp + masked_fill), the return cache is a distinct buffer fed by the return-space ring. The author signals the intermediate / return distinction by overriding `_get_intermediate_format` and/or `_get_intermediate_dtype` (a no-op override returning the return-space value is acceptable when shape and dtype coincide).
 
 ### Why shape is per-instance and dtype is class-uniform
 
@@ -157,7 +157,7 @@ The manager owns all storage. Conceptually there are four scopes:
 Per simulation step the manager:
 
 1. Rotates the per-dtype timeline ring pair and the per-class return-space ring pair, freeing the oldest slot for the new snapshot.
-2. For each sensor class, invokes `_update_shared_cache` once, passing the per-class slices of the intermediate cache, both timeline rings (GT + measured; `None` for classes that opted out), and the per-class return cache. The hook produces the ground-truth signal in the GT intermediate cache and the measured snapshot (post-physics, post-transform, post-hardware-imperfections) in the per-step working buffer.
+2. For each sensor class, invokes `_update_shared_cache` once, passing the per-class slices of the intermediate cache and both timeline rings (GT + measured; `None` for classes that opted out). The hook produces the ground-truth signal in the GT intermediate cache and the measured snapshot (post-physics, post-transform, post-hardware-imperfections) in the per-step working buffer.
 3. Runs `_post_process` on both branches and writes the result to slot 0 of the per-class return-space ring pair. Skipped when no return-space ring is allocated (alias-view propagates the per-step write automatically).
 4. Reads slot 0 of the GT return ring into the GT return cache; per-sensor delay-samples the measured return ring into the measured return cache. For sensors with `delay = 0` and no jitter this is just slot-0 reads.
 


### PR DESCRIPTION
## Summary

\`return_cache\` is no longer passed to \`_update_shared_cache\` hooks in \`genesis-world\` (it was unused - the manager handles return-space writes and delay sampling after the hook returns). This PR updates the two doc references that still showed it in the signature.

Companion to the upcoming Genesis PR that drops the parameter.