### PR TITLE
[DOC] Pack _apply_physics_imperfections inside _update_current_timestep_data; add is_measured to _apply_transform

### DIFF
--- a/source/user_guide/advanced_topics/sensors/custom_sensors.md
+++ b/source/user_guide/advanced_topics/sensors/custom_sensors.md
@@ -97,53 +97,42 @@ This is the only abstract hook of `SimpleSensor`. `_get_return_format` and `_get
 
 ### Optional overrides
 
-#### `_apply_transform(cls, shared_metadata, data, *, timeline)`
+#### `_apply_transform(cls, shared_metadata, data, timeline, *, is_measured)`
 
-Apply a coordinate transform and/or a stateful response model, in place, on `data` (a batch-first view `[B, cache_size, ...]`). Called twice per step: once on the ground-truth branch with the GT timeline ring, once on the measured branch with the measured timeline ring. Both rings hold post-transform, **PRE-hardware-imperfection** values, so recurrence reads (`timeline.at(1)` and earlier) are always clean of hardware noise.
+Apply a coordinate transform and/or a stateful response model, in place, on `data` (a batch-first view `[B, cache_size, ...]`). Called twice per step: once on the ground-truth branch with the GT timeline ring (`is_measured=False`), once on the measured branch with the measured timeline ring (`is_measured=True`). Both rings hold post-transform, **PRE-hardware-imperfection** values, so recurrence reads (`timeline.at(1)` and earlier) are always clean of hardware noise.
 
 - The coordinate-transform portion runs unconditionally on both branches.
 - The response-model portion (e.g. thermal dissipation, exponential moving average, low-pass) reads previous slots via `timeline.at(1)`, `timeline.at(2)`, etc. The current write target is `data` (alias of `timeline.at(0)`); do not double-write.
 - **Aliasing note:** `data is timeline.at(0, copy=False)` - they refer to the same memory. Use whichever reads more naturally.
+- Gate any sensor-element-specific pre-acquisition effect (RC time constant, mechanical bandwidth - things that belong to the sensor element and must not appear in GT) on `if is_measured:`. Branch-symmetric effects skip the gate.
 
 ```python
 @classmethod
-def _apply_transform(cls, shared_metadata, data, *, timeline):
+def _apply_transform(cls, shared_metadata, data, timeline, *, is_measured):
     # Coordinate transform: always runs on both branches.
     data.copy_(transform_by_quat(data, shared_metadata.world_to_local_quat))
 
-    # Stateful response model: reads the previous slot on the current branch's ring (one-pole low-pass with
-    # coefficient `alpha`, which the sensor's metadata subclass stored at build time).
-    prev = timeline.at(1)
-    data.mul_(1 - shared_metadata.alpha).add_(prev, alpha=shared_metadata.alpha)
+    # Sensor-element response model (RC time constant). Measured-only because GT must return the underlying
+    # physical phenomenon untouched by the sensor element.
+    if is_measured:
+        prev = timeline.at(1)
+        data.mul_(1 - shared_metadata.alpha).add_(prev, alpha=shared_metadata.alpha)
 ```
 
-`_apply_transform` runs symmetrically on both branches with the same code, so any contribution applies to both ground truth and measurement. For a response-model effect that should only affect the measurement (e.g. a sensor-element bandwidth that the ideal GT signal should not see), put it in `_post_process` with the `is_measured=True` branch - that hook receives the per-class return-space ring as `timeline` and can read previous post-everything outputs for stateful recurrence (see below).
+The default of running on both branches is what you want for any frame change or coordinate transform. Use the `is_measured` gate when the response is a property of the sensor element itself. For post-acquisition stateful effects (DSP filtering at the sensor output) use `_post_process` with `is_measured` instead - it sees the per-class return-space ring.
 
-#### `_post_process(cls, shared_metadata, tensor, *, timeline, is_measured) -> torch.Tensor`
+#### `_post_process(cls, shared_metadata, tensor, timeline, *, is_measured) -> torch.Tensor`
 
 Projection from intermediate space to return space. Override when the user-facing output type and/or shape differs from the pipeline-internal representation: bool threshold on `ContactSensor`, deadband + saturation on `ContactForceSensor`, etc. Return the post-cast tensor; the manager writes it into slot 0 of the per-class return-space ring, and (on the measured branch) then delay-samples that ring into the user-visible return cache.
 
 Called once per branch per step. `tensor` is the full per-class intermediate cache in intermediate space (the current step's input). `timeline` is the per-class return-space ring; it is rotated AFTER this call returns, so inside the override `timeline.at(0)` is the previous step's post-output, `timeline.at(1)` is the step before that, and so on - stateful overrides (e.g. a sensor-element bandwidth filter on the measured branch) use these for recurrence. `is_measured` distinguishes branches (`True` on the measured call, `False` on the GT call) so an override can apply readout-stage contributions on only one side.
 
-Designed for cast / clamp / threshold / mask / deadband / simple reductions and (optionally) stateful HW responses that should not contaminate `_apply_transform` recurrence. Stateless overrides do not need to touch `timeline` or `is_measured` - the standard cast pattern stays one line:
+Designed for cast / clamp / threshold / mask / deadband / simple reductions and (optionally) stateful post-acquisition DSP responses (anti-alias filter, decimation memory) that operate in **return space** on the projected signal. Pre-acquisition effects (RC filter on the underlying physical signal, mechanical bandwidth of the sensor element) belong in `_apply_transform` with `is_measured=True` instead - they need the intermediate-space ring. Stateless overrides do not need to touch `timeline` or `is_measured`:
 
 ```python
 @classmethod
-def _post_process(cls, shared_metadata, tensor, *, timeline, is_measured):
+def _post_process(cls, shared_metadata, tensor, timeline, *, is_measured):
     return tensor > shared_metadata.thresholds
-```
-
-Example of a stateful, measured-only sensor-element bandwidth filter (one-pole low-pass on the post-output value,
-fed by the previous post-everything snapshot from the return-space ring):
-
-```python
-@classmethod
-def _post_process(cls, shared_metadata, tensor, *, timeline, is_measured):
-    out = tensor.clone()
-    if is_measured:
-        prev = timeline.at(0)  # ring rotates after this call; at(0) is the previous step's post-output.
-        out.mul_(1 - shared_metadata.alpha).add_(prev, alpha=shared_metadata.alpha)
-    return out
 ```
 
 If you override `_post_process` you **must** also override `_get_intermediate_format` and/or `_get_intermediate_dtype`. The pipeline enforces this at class-definition time:
@@ -179,17 +168,17 @@ def _get_intermediate_dtype(cls) -> torch.dtype:
 
 When `_get_intermediate_format` and `_get_intermediate_dtype` both default, `_post_process` is identity, **and** no sensor in the class declares `delay > 0` or `history_length > 0` (the common case for most no-op sensors), the manager allocates **one** buffer and aliases the return cache as a view of the intermediate cache - no extra memory, no copy. Any of those triggers - overriding `_post_process`, non-zero delay, non-zero history - causes the manager to allocate a separate per-class return cache and a per-class return-space ring to back delay sampling and history reads.
 
-#### `_apply_physics_imperfections(cls, shared_metadata, measured_slot_0)`
+#### `_apply_physics_imperfections(cls, shared_metadata, measured_slot_0, timeline)`
 
-Apply physics-level imperfections in place on the measured ring's current slot, **before** `_apply_transform`. Default: no-op. Override when the imperfection represents a property of the simulated phenomenon itself (e.g. genuine drift in the physical quantity being sensed) and therefore must propagate through the response model on subsequent steps. The contribution becomes part of the measured ring's slot 0 and feeds the next step's transform recurrence.
+Apply physics-level imperfections in place on the **measured** ring's current slot, **before** `_apply_transform`. Default: no-op. Override when the simulator does not model a random fluctuation of the underlying phenomenon (genuine drift of the physical quantity, fine-scale turbulence on top of the deterministic field, etc.) and that fluctuation should propagate through the sensor's response model on subsequent steps. Measured-only by construction so GT keeps the raw simulated phenomenon - if you want the noise on both branches, write it into the simulator state instead.
 
-This is the right home for "physics random walk" - drift that lives in the simulated world rather than in the sensor's readout stage. Anything that should *not* feed the response model (sensor electronics noise, ADC quantization) belongs in `_apply_hardware_imperfections` instead.
+This hook is **called from inside the default `_update_current_timestep_data`**, immediately after the raw signal is mirrored into the measured slot. A sensor that needs `_update_raw_data` and `_apply_physics_imperfections` fused in a single kernel pass should override `_update_current_timestep_data` instead of this hook (see [Kernel-internal physics noise](#kernel-internal-physics-noise) below). Anything that belongs to the sensor's readout electronics (noise, ADC quantization) belongs in `_apply_hardware_imperfections`; anything that belongs to the sensor element (RC time constant, mechanical bandwidth) belongs in `_apply_transform` with the `is_measured=True` gate.
 
 #### `_apply_hardware_imperfections(cls, shared_metadata, measured_slot_0)`
 
 `SimpleSensor` already implements an opinionated interpretation of `noise`, `bias`, `random_walk`, and `resolution` as the perturbations the embedded sampler introduces at the sensor output. Applied to the per-step measured working buffer **before** `_post_process` (and before the post-`_post_process` snapshot is frozen into the per-class return-space ring); the timeline ring is never written to, so `_apply_transform` recurrence stays clean. This is the **measured-only** stage of the pipeline; nothing here is mirrored on the GT branch.
 
-Designed for stateless per-step perturbations. Stateful HW responses (sensor-element bandwidth, signal-dependent gain with memory) belong in `_post_process`, which sees the per-class return-space ring and can read its previous slots via `timeline.at(0)` and earlier (the return ring rotates after `_post_process` returns).
+Designed for stateless per-step perturbations. Stateful sensor-element effects (RC time constant, mechanical bandwidth) belong in `_apply_transform` with the `is_measured` gate (intermediate-space recurrence). Stateful post-acquisition DSP (anti-alias, decimation memory) belongs in `_post_process`, which sees the per-class return-space ring and can read its previous slots via `timeline.at(0)` and earlier (the return ring rotates after `_post_process` returns).
 
 Override when your sensor has a non-standard imperfection model. You typically still call `super()._apply_hardware_imperfections(...)` for the standard pieces and add your custom term on top:
 
@@ -204,7 +193,7 @@ def _apply_hardware_imperfections(cls, shared_metadata, measured_slot_0):
 
 #### `_update_current_timestep_data(cls, shared_metadata, current_ground_truth_data_T, ground_truth_data_timeline, measured_data_timeline)`
 
-Default behavior: call `_update_raw_data` to produce the ground-truth value into the contiguous `(cols, B)` kernel target `current_ground_truth_data_T`, then mirror it into the GT ring's slot 0 and the measured ring's slot 0. Override **only** when your sensor has **kernel-internal physical-response noise**, i.e. when the ground-truth signal and the measured signal must be produced by a single kernel pass with different paths inside. The default split (one kernel, then mirror) is correct for every other case. See [Kernel-internal physics noise](#kernel-internal-physics-noise) below.
+Default behavior: call `_update_raw_data` to produce the ground-truth value into the contiguous `(cols, B)` kernel target `current_ground_truth_data_T`, mirror it into the GT ring's slot 0 and the measured ring's slot 0, then call `_apply_physics_imperfections` in place on the measured slot. Override this method to fuse `_update_raw_data` and `_apply_physics_imperfections` in a single kernel pass: write the raw GT to `current_ground_truth_data_T` and to the GT ring slot, and write the noised value directly to the measured ring slot. The rest of the pipeline (`_apply_transform`, hardware imperfections, `_post_process`, delay sampling) still runs unchanged on top. See [Kernel-internal physics noise](#kernel-internal-physics-noise) below.
 
 #### `uses_ring_pipeline` (class attribute, `ClassVar[bool]`)
 
@@ -225,7 +214,7 @@ Some sensors have noise that is **intrinsic to the physics computation** - a sin
 
 Two supported routes:
 
-1. **Override `_update_current_timestep_data` on `SimpleSensor`.** Your kernel writes `current_ground_truth_data_T` (the contiguous `(cols, B)` GT slice) **and** `measured_data_timeline.at(0, copy=False)` (the measured slot 0, `(B, cols)`) in one pass, and (when allocated) `ground_truth_data_timeline.at(0, copy=False)` (the GT slot 0). The rest of the SimpleSensor pipeline (`_apply_physics_imperfections`, `_apply_transform` on both branches, delay sampling, `_apply_hardware_imperfections`, eager `_post_process`) still runs on top. Recommended when you also want any of the standard pipeline pieces (imperfection parameters, delay/jitter, `_post_process` projection).
+1. **Override `_update_current_timestep_data` on `SimpleSensor`.** Your kernel writes `current_ground_truth_data_T` (the contiguous `(cols, B)` GT slice) **and** `measured_data_timeline.at(0, copy=False)` (the measured slot 0, `(B, cols)`) in one pass, and (when allocated) `ground_truth_data_timeline.at(0, copy=False)` (the GT slot 0). Because `_apply_physics_imperfections` is packed inside this hook, your override naturally fuses raw + physical-response noise. The rest of the SimpleSensor pipeline (`_apply_transform` on both branches, delay sampling, `_apply_hardware_imperfections`, eager `_post_process`) still runs on top. Recommended when you also want any of the standard pipeline pieces (imperfection parameters, delay/jitter, `_post_process` projection).
 2. **Derive from `Sensor` directly and override `_update_shared_cache`.** Skips the SimpleSensor chain entirely. The override receives `(metadata, gt_T, gt_timeline, measured_timeline, intermediate_cache)` and is responsible for populating them. The manager handles `_post_process` projection, return-space ring writes, and delay sampling after the hook returns. Use this when the sensor needs a fundamentally non-standard pipeline (e.g. cameras and renderers).
 
 ## Camera-style sensors via `BaseCameraSensor`

--- a/source/user_guide/advanced_topics/sensors/sensor_pipeline.md
+++ b/source/user_guide/advanced_topics/sensors/sensor_pipeline.md
@@ -19,7 +19,7 @@ The robot's `read()` is a **memory lookup**. It does not trigger sensor acquisit
 
 This shapes every design decision in the pipeline. Imperfections split into two layers depending on where the imperfection physically lives:
 
-- **Physics-level imperfections** are properties of the physical phenomenon being sensed (e.g. genuine drift in the simulated process, low-pass coupling in a thermistor's surroundings). They accumulate through the sensor's response model and therefore must propagate through transform recurrence. They are written into the timeline ring and read by `_apply_transform` on the following step.
+- **Physics-level imperfections** are random fluctuations of the underlying physical phenomenon the simulator does not model (genuine drift of the simulated quantity, fine-scale turbulence on top of a deterministic field, etc.). They shape what the sensor *sees* beyond the simulated GT and propagate through the sensor's response model on subsequent steps, so they live on the **measured** timeline ring (GT keeps the raw simulated phenomenon). They are packed inside `_update_current_timestep_data` together with the raw-signal kernel so a sensor can fuse "raw + noise" in a single kernel pass.
 - **Hardware-level imperfections** are properties of the sensor's own readout stage (electronic noise, ADC quantization, sensor-output drift). They are applied at the sensor-output stage, on the per-step working buffer - never on the timeline ring. The post-`_post_process` snapshot is frozen into the return-space ring slot 0, so each captured snapshot carries the imperfection state that was sampled at that step. Transform recurrence reads only the timeline ring (clean of hardware noise), so a stateful response model (thermal dissipation, low-pass filter) is never amplified by hardware noise of the previous step.
 - **Delay (and its jitter)** is the staleness of the snapshot relative to "now". A sensor with `delay = D` (plus a random `jitter` drawn each step) means: at control-loop time `t`, the robot's read returns the post-everything value captured at time `t - D - jitter_t` (response-model output + the hardware imperfection sample that was drawn at that step). `delay` and `jitter` always travel together - jitter cannot exceed delay. Sampling is zero-order-hold (ZOH) by default, which is dtype-safe for arbitrary return types (bool, uint8, quantized float) and is the right semantics for a snapshot that is meant to look "frozen at capture". Sensors whose return space is a continuous-valued float and that benefit from a smoother sampling rule can override `_apply_delay`.
 - **Reads are idempotent within a step.** If a design implies they aren't, the abstraction is broken.
@@ -43,7 +43,7 @@ Camera (RasterizerCameraSensor, RaytracerCameraSensor, BatchRendererCameraSensor
 - it has its own rendering path and does not use the SimpleSensor pipeline.
 ```
 
-`Sensor` is the minimal customization contract - a single abstract per-step compute method (`_update_shared_cache`), four spec accessors (`_get_return_format` / `_get_intermediate_format` as instance methods for shape; `_get_cache_dtype` / `_get_intermediate_dtype` as classmethods for dtype), a `_post_process` projection (identity by default), and a class-level capability flag (`uses_ring_pipeline: ClassVar[bool] = True`) telling the manager whether to allocate the per-step timeline rings (GT + measured) for the class. `SimpleSensor` builds the standard pipeline on top, exposing five override hooks (`_update_raw_data`, `_update_current_timestep_data`, `_apply_physics_imperfections`, `_apply_transform`, `_apply_hardware_imperfections`) that concrete sensors override as needed. Signatures, contracts, and worked examples are in [Implementing Custom Sensors](custom_sensors.md). This page focuses on what those hooks *do* at runtime - the order in which they fire and the buffers they read and write.
+`Sensor` is the minimal customization contract - a single abstract per-step compute method (`_update_shared_cache`), four spec accessors (`_get_return_format` / `_get_intermediate_format` as instance methods for shape; `_get_cache_dtype` / `_get_intermediate_dtype` as classmethods for dtype), a `_post_process` projection (identity by default), and a class-level capability flag (`uses_ring_pipeline: ClassVar[bool] = True`) telling the manager whether to allocate the per-step timeline rings (GT + measured) for the class. `SimpleSensor` builds the standard pipeline on top, exposing five override hooks (`_update_raw_data`, `_update_current_timestep_data`, `_apply_physics_imperfections`, `_apply_transform`, `_apply_hardware_imperfections`) that concrete sensors override as needed. `_update_raw_data` and `_apply_physics_imperfections` are packed inside `_update_current_timestep_data` so a sensor that needs them fused in a single kernel pass can override that one hook. Signatures, contracts, and worked examples are in [Implementing Custom Sensors](custom_sensors.md). This page focuses on what those hooks *do* at runtime - the order in which they fire and the buffers they read and write.
 
 ## Per-step pipeline
 
@@ -53,12 +53,16 @@ Camera (RasterizerCameraSensor, RaytracerCameraSensor, BatchRendererCameraSensor
   _update_current_timestep_data
             │  raw -> GT intermediate cache  (kernel target, contiguous (cols, B))
             │  mirrored to GT timeline ring slot 0  +  measured timeline ring slot 0
+            │  _apply_physics_imperfections(measured slot 0)  [packed here so a
+            │  sensor with kernel-internal physical-response noise can fuse raw +
+            │  noise in a single kernel by overriding this hook]
             │
             ├──► [GT branch]
             │       │
             │       ▼
-            │   _apply_transform(GT slot 0, timeline=GT timeline ring)
-            │       │  (reads previous slots for stateful response models)
+            │   _apply_transform(GT slot 0, timeline=GT timeline ring, is_measured=False)
+            │       │  (reads previous slots for stateful response models;
+            │       │   is_measured=False skips sensor-element-specific effects)
             │       ▼
             │   GT slot 0 is the post-transform value; copied back into GT
             │   intermediate cache
@@ -75,12 +79,10 @@ Camera (RasterizerCameraSensor, RaytracerCameraSensor, BatchRendererCameraSensor
             └──► [measured branch]
                     │
                     ▼
-                _apply_physics_imperfections(measured slot 0)
-                    │  (default no-op; physics-level imperfections that should
-                    │   propagate through transform recurrence)
-                    ▼
-                _apply_transform(measured slot 0, timeline=measured timeline ring)
-                    │  (recurrence reads clean pre-hardware previous slots)
+                _apply_transform(measured slot 0, timeline=measured timeline ring, is_measured=True)
+                    │  (recurrence reads clean pre-hardware previous slots;
+                    │   is_measured=True activates sensor-element-specific effects
+                    │   such as RC time constant / mechanical bandwidth)
                     ▼
                 measured slot 0 holds post-physics, post-transform value
                     │
@@ -177,7 +179,7 @@ Two options classes feed the pipeline. `SensorOptions` carries the time-related 
 | `random_walk` | 0.0 | Std-dev of the random-walk step. The drift accumulator advances each step and is added to the output, then frozen into the return-space ring slot at capture time, so a delayed read sees the drift the sensor had at the moment it was captured. |
 | `resolution` | 0.0 | Quantization step. Output values are rounded to multiples of this. |
 
-`noise`, `bias`, `random_walk`, `resolution` are deliberately generic - they're imperfection *parameters*. `SimpleSensor._apply_hardware_imperfections` picks the "embedded sampler" interpretation laid out above (sensor-output stage). A direct `Sensor` subclass could interpret them differently or ignore them entirely (Camera does). Imperfections that need to propagate through the response model (e.g. genuine drift in the physical phenomenon being sensed) belong in an `_apply_physics_imperfections` override instead - that hook runs **before** `_apply_transform` so its contribution feeds the next step's recurrence.
+`noise`, `bias`, `random_walk`, `resolution` are deliberately generic - they're imperfection *parameters*. `SimpleSensor._apply_hardware_imperfections` picks the "embedded sampler" interpretation laid out above (sensor-output stage). A direct `Sensor` subclass could interpret them differently or ignore them entirely (Camera does). Imperfections that need to propagate through the response model (e.g. genuine drift in the physical phenomenon being sensed) belong in an `_apply_physics_imperfections` override instead - that hook runs inside `_update_current_timestep_data` on the measured timeline slot, **before** `_apply_transform` reads it, so its contribution feeds the next step's recurrence and can be fused with the raw-signal kernel in one pass.
 
 ### Why imperfections are baked in at capture time
 


### PR DESCRIPTION
## Summary

Sync the sensor pipeline docs to match the refactor in the Genesis code PR:

- `_apply_physics_imperfections` is now **measured-only** by construction and **packed inside** the default `_update_current_timestep_data` (called after the raw signal is mirrored into the measured ring slot). A sensor that needs raw + physical-response noise fused in a single kernel pass overrides `_update_current_timestep_data`. GT keeps the raw simulated phenomenon untouched.
- `_apply_transform` gains a kw-only `is_measured: bool`. It still runs on both branches; sensor-element-specific pre-acquisition effects (RC time constant, mechanical bandwidth) gate on `if is_measured:`. Branch-symmetric effects (coordinate transforms) skip the gate.
- The temperature RC filter is the canonical `is_measured`-gated `_apply_transform` example; `_post_process` is reserved for post-acquisition DSP.
- Updated pipeline diagram, hook taxonomy, and the kernel-fusion section in `custom_sensors.md`.

## Test plan
- [ ] Read both files end-to-end and confirm the pipeline diagram matches the code in the companion Genesis PR.