### PR TITLE
[DOC] Strip stale interpolate option from IMU docs

### DIFF
--- a/source/api_reference/sensor/imu.md
+++ b/source/api_reference/sensor/imu.md
@@ -76,7 +76,6 @@ gs.sensors.IMU(
     # Timing
     delay=0.0,                                 # Read delay in seconds
     jitter=0.0,                                # Random delay jitter in seconds
-    interpolate=False,                         # Interpolate delayed measurements
 
     draw_debug=True,
 )

--- a/source/user_guide/getting_started/sensors/imu.md
+++ b/source/user_guide/getting_started/sensors/imu.md
@@ -47,7 +47,6 @@ imu = scene.add_sensor(
         gyro_random_walk=(0.001, 0.001, 0.001),
         delay=0.01,
         jitter=0.01,
-        interpolate=True,
         draw_debug=True,
     )
 )
@@ -60,7 +59,6 @@ The IMU constructor exposes:
 - `acc_noise` / `gyro_noise` - Gaussian noise per axis.
 - `acc_random_walk` / `gyro_random_walk` - gradual drift over time.
 - `delay` / `jitter` - timing realism.
-- `interpolate` - smooth delayed measurements between ring slots.
 - `draw_debug` - visualize the sensor frame in the viewer.
 
 ## Motion control and simulation


### PR DESCRIPTION
## Summary

Removes leftover `interpolate` references in IMU docs - the option was removed from Genesis when ZOH delay sampling became the default.

- `api_reference/sensor/imu.md`: drop `interpolate=False` from the constructor signature.
- `user_guide/getting_started/sensors/imu.md`: drop `interpolate=True` from the example and its bullet from the constructor reference.