### PR TITLE
[MISC] Remove Discord and WeChat badges from docs

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -75,11 +75,6 @@ html_theme_options = {
             "icon": "fa-brands fa-github",
         },
         {
-            "name": "Discord",
-            "url": "https://discord.gg/nukCuhB47p",
-            "icon": "fa-brands fa-discord",
-        },
-        {
             "name": "PyPI",
             "url": "https://pypi.org/project/genesis-world/",
             "icon": "fa-brands fa-python",

--- a/source/index.md
+++ b/source/index.md
@@ -5,8 +5,6 @@
 [![GitHub Repo stars](https://img.shields.io/github/stars/Genesis-Embodied-AI/Genesis?style=plastic&logo=GitHub&logoSize=auto)](https://github.com/Genesis-Embodied-AI/Genesis)
 [![PyPI version](https://badge.fury.io/py/genesis-world.svg?icon=si%3Apython)](https://pypi.org/project/genesis-world/)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Fgenesis-embodied-ai.github.io%2F)](https://genesis-embodied-ai.github.io/)
-[![Discord](https://img.shields.io/discord/1322086972302430269?logo=discord)](https://discord.gg/nukCuhB47p)
-<a href="https://drive.google.com/uc?export=view&id=1ZS9nnbQ-t1IwkzJlENBYqYIIOOZhXuBZ"><img src="https://img.shields.io/badge/WeChat-07C160?style=for-the-badge&logo=wechat&logoColor=white" height="20" style="display:inline"></a>
 
 
 ## What is Genesis World?


### PR DESCRIPTION
## Description

Removes the Discord and WeChat badges from the docs landing page (`source/index.md`) and the Discord icon link from the navbar (`source/conf.py`).

## Motivation and Context

The WeChat and Discord has been unmaintained and we are removing these channels to make things more manageable for the team. Discussions about Genesis World should take place in [GitHub discussions](https://github.com/Genesis-Embodied-AI/genesis-world/discussions) and issues!

## How Has This Been / Can This Be Tested?

Build the docs and confirm the landing-page badges and the navbar no longer show Discord/WeChat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
