### PR TITLE
Refresh the API Reference: style, dedup, and coverage

### DIFF
--- a/source/api_reference/differentiation/creation_ops.md
+++ b/source/api_reference/differentiation/creation_ops.md
@@ -75,5 +75,5 @@ combined = pos + external  # Result is Genesis World tensor
 
 ## See also
 
-- {doc}`tensor` - Genesis World Tensor class
-- {doc}`index` - Differentiable simulation overview
+- {doc}`tensor`: Genesis World Tensor class
+- {doc}`index`: Differentiable simulation overview

--- a/source/api_reference/differentiation/creation_ops.md
+++ b/source/api_reference/differentiation/creation_ops.md
@@ -68,8 +68,9 @@ combined = pos + external  # Result is Genesis World tensor
 
 ```{eval-rst}
 .. automodule:: genesis.grad.creation_ops
-   :members:
-   :undoc-members:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/differentiation/tensor.md
+++ b/source/api_reference/differentiation/tensor.md
@@ -82,5 +82,5 @@ if pos.scene is not None:
 
 ## See also
 
-- {doc}`index` - Differentiable simulation overview
-- {doc}`creation_ops` - Creating tensors
+- {doc}`index`: Differentiable simulation overview
+- {doc}`creation_ops`: Creating tensors

--- a/source/api_reference/differentiation/tensor.md
+++ b/source/api_reference/differentiation/tensor.md
@@ -1,4 +1,4 @@
-# Tensor
+# `Tensor`
 
 The `genesis.grad.Tensor` class extends `torch.Tensor` to support end-to-end gradient flow through Genesis World simulations.
 
@@ -75,9 +75,9 @@ if pos.scene is not None:
 
 ```{eval-rst}
 .. autoclass:: genesis.grad.tensor.Tensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/engine/couplers/ipc_coupler.md
+++ b/source/api_reference/engine/couplers/ipc_coupler.md
@@ -1,17 +1,8 @@
-# IPCCoupler
+# `IPCCoupler`
 
-The `IPCCoupler` (Incremental Potential Contact) provides robust contact handling for multi-physics scenarios.
+The `IPCCoupler` uses Incremental Potential Contact (IPC), a barrier-based, intersection-free contact model built on [libuipc](https://github.com/spiriMirror/libuipc). It unifies rigid bodies (handled as affine-body-dynamics objects) and FEM bodies in one contact framework, and is the right choice for cloth and large-deformation soft bodies where robustness matters more than speed. Select it by passing `gs.options.IPCCouplerOptions` to the scene.
 
-## Overview
-
-IPC coupling:
-
-- Variational contact formulation
-- Guaranteed intersection-free trajectories
-- Robust for challenging contact scenarios
-- Higher computational cost
-
-## Usage
+## Minimal example
 
 ```python
 import genesis as gs
@@ -19,18 +10,19 @@ import genesis as gs
 gs.init()
 scene = gs.Scene(
     coupler_options=gs.options.IPCCouplerOptions(
-        d_hat=0.001,  # Contact distance threshold
+        contact_d_hat=0.01,  # barrier activation distance, meters
     ),
 )
 ```
 
-## When to use IPC
+Coupling then happens automatically as the scene steps; there is no per-step coupling call.
 
-- Complex deformable-deformable contact
-- Scenarios requiring intersection-free guarantees
-- When stability is more important than speed
+## Configuration
+
+`IPCCouplerOptions` exposes the Newton solver controls (`newton_max_iterations`, `newton_tolerance`), the contact settings (`contact_d_hat`, the barrier activation distance, and `contact_friction_enable`), and the linear-system solver choice. Fields left as `None` fall back to the libuipc defaults (for example `contact_d_hat` defaults to `0.01`). See {doc}`/api_reference/options/simulator_coupler_and_solver_options/ipc_coupler_options` for the full list.
 
 ## See also
 
-- {doc}`index` - Coupler overview
-- {doc}`/api_reference/options/simulator_coupler_and_solver_options/coupler_options` - Coupler options
+- {doc}`index`: coupler overview and how to choose one.
+- {doc}`/user_guide/theory/couplers/index`: the theory behind each coupler.
+- {doc}`/api_reference/options/simulator_coupler_and_solver_options/ipc_coupler_options`: IPC coupler options.

--- a/source/api_reference/engine/couplers/legacy_coupler.md
+++ b/source/api_reference/engine/couplers/legacy_coupler.md
@@ -1,29 +1,33 @@
-# LegacyCoupler
+# `LegacyCoupler`
 
-The `LegacyCoupler` provides basic impulse-based coupling between different physics solvers.
+The `LegacyCoupler` is the default coupler. It handles every cross-solver pair (rigid, MPM, SPH, PBD, FEM) and is the right choice for general multi-physics scenes. It is slated for deprecation in favor of the SAP and IPC couplers. The scene uses it when you pass no `coupler_options`.
 
-## Overview
-
-The Legacy coupler:
-
-- Uses impulse-based contact resolution
-- Handles rigid-soft interactions
-- Simple and fast for basic scenarios
-
-## Usage
+## Minimal example
 
 ```python
 import genesis as gs
 
 gs.init()
+scene = gs.Scene()  # LegacyCoupler is selected by default
+```
+
+To disable coupling for a specific pair of solvers, pass `gs.options.LegacyCouplerOptions` with that pair set to `False`:
+
+```python
 scene = gs.Scene(
     coupler_options=gs.options.LegacyCouplerOptions(
-        friction=0.5,
+        rigid_mpm=True,   # rigid <-> MPM coupling (default True)
+        rigid_sph=False,  # disable rigid <-> SPH coupling
     ),
 )
 ```
 
+## Configuration
+
+Each field of `LegacyCouplerOptions` is a boolean that enables one solver pair (`rigid_mpm`, `rigid_sph`, `rigid_pbd`, `rigid_fem`, `mpm_sph`, `mpm_pbd`, `fem_mpm`, `fem_sph`), all `True` by default. See {doc}`/api_reference/options/simulator_coupler_and_solver_options/legacy_coupler_options` for the full list.
+
 ## See also
 
-- {doc}`index` - Coupler overview
-- {doc}`sap_coupler` - Spatial acceleration
+- {doc}`index`: coupler overview and how to choose one.
+- {doc}`/user_guide/theory/couplers/index`: the theory behind each coupler.
+- {doc}`/api_reference/options/simulator_coupler_and_solver_options/legacy_coupler_options`: legacy coupler options.

--- a/source/api_reference/engine/couplers/sap_coupler.md
+++ b/source/api_reference/engine/couplers/sap_coupler.md
@@ -1,16 +1,8 @@
-# SAPCoupler
+# `SAPCoupler`
 
-The `SAPCoupler` (Sweep and Prune) provides efficient spatial acceleration for multi-physics coupling.
+The `SAPCoupler` resolves cross-solver contact with the Semi-Analytic Primal (SAP) contact solver used in [Drake](https://drake.mit.edu/). It targets accurate rigid-deformable contact, including hydroelastic contact against implicit FEM bodies. Select it by passing `gs.options.SAPCouplerOptions` to the scene.
 
-## Overview
-
-The SAP coupler:
-
-- Uses sweep-and-prune for broad-phase collision
-- Efficient for large numbers of objects
-- Reduces narrow-phase checks
-
-## Usage
+## Minimal example
 
 ```python
 import genesis as gs
@@ -21,7 +13,14 @@ scene = gs.Scene(
 )
 ```
 
+Coupling then happens automatically as the scene steps; there is no per-step coupling call.
+
+## Configuration
+
+`SAPCouplerOptions` exposes the SAP convergence controls (`n_sap_iterations`, `n_pcg_iterations`, `sap_convergence_atol`), the contact stiffnesses (`hydroelastic_stiffness` and `point_contact_stiffness`, both `1e8` by default), and the per-pair contact types (`fem_floor_contact_type`, `rigid_rigid_type`, and related fields). See {doc}`/api_reference/options/simulator_coupler_and_solver_options/sap_coupler_options` for the full list.
+
 ## See also
 
-- {doc}`index` - Coupler overview
-- {doc}`ipc_coupler` - IPC coupling
+- {doc}`index`: coupler overview and how to choose one.
+- {doc}`/user_guide/theory/couplers/index`: the theory behind each coupler.
+- {doc}`/api_reference/options/simulator_coupler_and_solver_options/sap_coupler_options`: SAP coupler options.

--- a/source/api_reference/engine/solvers/fem_solver.md
+++ b/source/api_reference/engine/solvers/fem_solver.md
@@ -1,25 +1,10 @@
-# FEMSolver
+# `FEMSolver`
 
-The `FEMSolver` implements the Finite Element Method for simulating deformable solids on tetrahedral meshes.
-
-## Overview
-
-The FEM solver:
-
-- Uses tetrahedral mesh elements.
-- Supports several constitutive models (linear, stable Neo-Hookean, linear corotated).
-- Handles large deformations (geometric nonlinearity).
-- Offers an explicit integrator by default and an optional implicit solver.
-
-## Supported materials
-
-| Material | Description |
-|----------|-------------|
-| `FEM.Elastic` | Elastic solid with selectable constitutive model |
-| `FEM.Muscle` | Active muscle contraction |
-| `FEM.Cloth` | Thin-shell cloth |
+The `FEMSolver` implements the Finite Element Method for simulating deformable solids on tetrahedral meshes. It supports several constitutive models (linear, stable Neo-Hookean, linear corotated), handles large deformations, and offers an explicit integrator by default with an optional implicit solver for stability at larger time steps. The materials it supports are listed in {doc}`/api_reference/material/fem/index`.
 
 ## Usage
+
+The solver activates when the scene contains an FEM entity. Configure it through `FEMOptions`; see {doc}`/api_reference/options/simulator_coupler_and_solver_options/fem_options` for the full option set.
 
 ```python
 import genesis as gs
@@ -47,17 +32,6 @@ scene.build()
 for i in range(1000):
     scene.step()
 ```
-
-## Configuration
-
-Key options in `FEMOptions`:
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `dt` | float | inherited | Substep duration in seconds. Inherits from `SimOptions` if not set. |
-| `damping` | float | `0.0` | Damping factor. |
-| `use_implicit_solver` | bool | `False` | Use the implicit solver, which is more stable at large time steps. |
-| `enable_vertex_constraints` | bool | `False` | Allow vertex constraints under the implicit solver. |
 
 ## Vertex constraints
 

--- a/source/api_reference/engine/solvers/mpm_solver.md
+++ b/source/api_reference/engine/solvers/mpm_solver.md
@@ -1,27 +1,10 @@
-# MPMSolver
+# `MPMSolver`
 
-The `MPMSolver` implements the Material Point Method (MPM) for simulating a wide range of materials including elastic solids, granular materials, fluids, and phase transitions.
-
-## Overview
-
-MPM combines:
-
-- **Lagrangian particles:** track material points.
-- **Eulerian grid:** solve the momentum equations.
-- **Particle-grid transfers:** MLS-MPM for stability.
-
-## Supported materials
-
-| Material | Description |
-|----------|-------------|
-| `MPM.Elastic` | Neo-Hookean elasticity |
-| `MPM.ElastoPlastic` | Plasticity with yield |
-| `MPM.Sand` | Drucker-Prager granular |
-| `MPM.Snow` | Snow plasticity |
-| `MPM.Liquid` | Weakly compressible fluid |
-| `MPM.Muscle` | Active muscle material |
+The `MPMSolver` implements the Material Point Method (MPM) for simulating a wide range of materials including elastic solids, granular materials, fluids, and phase transitions. It combines Lagrangian particles that track material points with a background Eulerian grid that solves the momentum equations, transferring between them with MLS-MPM for stability. The materials it supports are listed in {doc}`/api_reference/material/mpm/index`.
 
 ## Usage
+
+The solver activates when the scene contains an MPM entity. Configure the background grid through `MPMOptions`; see {doc}`/api_reference/options/simulator_coupler_and_solver_options/mpm_options` for the full option set.
 
 ```python
 import genesis as gs
@@ -50,54 +33,6 @@ scene.build()
 
 for i in range(1000):
     scene.step()
-```
-
-## Configuration
-
-Key options in `MPMOptions`:
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `dt` | float | inherited | Substep duration in seconds. Inherits from `SimOptions` if not set. |
-| `lower_bound` | tuple | `(-1, -1, 0)` | Lower corner of the simulation domain. |
-| `upper_bound` | tuple | `(1, 1, 1)` | Upper corner of the simulation domain. |
-| `grid_density` | float | `64` | Grid cells per meter. |
-| `particle_size` | float | auto | Particle diameter in meters; derived from `grid_density` if not set. |
-| `enable_CPIC` | bool | `False` | Enable CPIC for coupling with thin objects. |
-
-## Grid setup
-
-MPM requires a background grid for computation:
-
-```python
-mpm_options = gs.options.MPMOptions(
-    lower_bound=(-2, -2, 0),   # Grid min
-    upper_bound=(2, 2, 4),     # Grid max
-    grid_density=128,          # Resolution
-)
-```
-
-## Material parameters
-
-### Elastic material
-
-```python
-material = gs.materials.MPM.Elastic(
-    E=1e5,     # Young's modulus, Pa
-    nu=0.3,    # Poisson's ratio
-    rho=1000,  # density, kg/m^3
-)
-```
-
-### Granular (sand)
-
-```python
-material = gs.materials.MPM.Sand(
-    E=1e6,
-    nu=0.2,
-    rho=1500,
-    friction_angle=30,  # degrees
-)
 ```
 
 ## See also

--- a/source/api_reference/engine/solvers/pbd_solver.md
+++ b/source/api_reference/engine/solvers/pbd_solver.md
@@ -1,6 +1,6 @@
-# PBDSolver
+# `PBDSolver`
 
-The `PBDSolver` implements Position Based Dynamics for simulating cloth, soft bodies, and particle systems with fast, stable steps.
+The `PBDSolver` implements Position Based Dynamics for simulating cloth, soft bodies, and particle systems with fast, stable steps. The materials it supports are listed in {doc}`/api_reference/material/pbd/index`.
 
 ## Overview
 
@@ -17,16 +17,9 @@ Advantages:
 - **Speed:** cheap iterative projection.
 - **Controllability:** direct position control.
 
-## Supported materials
-
-| Material | Description |
-|----------|-------------|
-| `PBD.Cloth` | Cloth and fabric |
-| `PBD.Elastic` | Soft elastic (3D) bodies |
-| `PBD.Particle` | Free particle systems |
-| `PBD.Liquid` | Position-based fluids |
-
 ## Usage
+
+The solver activates when the scene contains a PBD entity. Configure it through `PBDOptions`; see {doc}`/api_reference/options/simulator_coupler_and_solver_options/pbd_options` for the full option set.
 
 ```python
 import genesis as gs
@@ -57,19 +50,6 @@ for i in range(1000):
     scene.step()
 ```
 
-## Configuration
-
-Key options in `PBDOptions`:
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `max_stretch_solver_iterations` | int | `4` | Iterations for the stretch constraints. |
-| `max_bending_solver_iterations` | int | `1` | Iterations for the bending constraints. |
-| `max_volume_solver_iterations` | int | `1` | Iterations for the volume constraints. |
-| `max_density_solver_iterations` | int | `1` | Iterations for the density (fluid) constraints. |
-| `particle_size` | float | `1e-2` | Particle diameter in meters, used for self-collision. |
-| `gravity` | tuple | inherited | Override gravity. Inherits from `SimOptions` if not set. |
-
 ## Constraint types
 
 PBD applies several constraint groups, each with its own iteration count:
@@ -79,22 +59,7 @@ PBD applies several constraint groups, each with its own iteration count:
 - **Volume constraints:** preserve enclosed volume.
 - **Density constraints:** enforce incompressibility for fluids.
 
-## Cloth material parameters
-
-`PBD.Cloth` is parameterized by compliances and relaxation factors rather than raw stiffnesses:
-
-```python
-cloth = scene.add_entity(
-    gs.morphs.Mesh(file="cloth.obj"),
-    material=gs.materials.PBD.Cloth(
-        stretch_compliance=1e-7,   # m/N
-        bending_compliance=1e-5,   # rad/N
-        stretch_relaxation=0.3,    # smaller weakens the stretch constraint
-        bending_relaxation=0.1,    # smaller weakens the bending constraint
-        air_resistance=1e-3,       # damping from air drag
-    ),
-)
-```
+Each group has its own iteration count in `PBDOptions`.
 
 ## See also
 

--- a/source/api_reference/engine/solvers/rigid_solver.md
+++ b/source/api_reference/engine/solvers/rigid_solver.md
@@ -1,4 +1,4 @@
-# RigidSolver
+# `RigidSolver`
 
 The `RigidSolver` handles rigid body dynamics, including articulated bodies, robots, and rigid objects.
 
@@ -40,20 +40,6 @@ robot.set_dofs_velocity(target_velocities)
 for i in range(1000):
     scene.step()
 ```
-
-## Configuration
-
-Key options in `RigidOptions`:
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `enable_collision` | bool | `True` | Enable collision detection. |
-| `enable_joint_limit` | bool | `True` | Enforce joint limits. |
-| `enable_self_collision` | bool | `True` | Enable self-collision within each entity. |
-| `constraint_solver` | enum | `Newton` | Constraint solver: `gs.constraint_solver.CG` or `gs.constraint_solver.Newton`. |
-| `iterations` | int | `50` | Constraint solver iterations. |
-| `max_collision_pairs` | int | `150` | Maximum number of candidate collision pairs. |
-| `max_contacts` | int \| None | `None` | Maximum contact points per environment; resolved automatically when `None`. |
 
 ## Collision detection
 

--- a/source/api_reference/engine/solvers/sf_solver.md
+++ b/source/api_reference/engine/solvers/sf_solver.md
@@ -1,14 +1,8 @@
-# SFSolver
+# `SFSolver`
 
 The `SFSolver` is the Stable Fluid solver: a grid-based (Eulerian) solver for gaseous phenomena such as smoke. It advects a velocity field and one or more scalar density fields on a fixed 3D grid, then makes the velocity field divergence-free with a Jacobi pressure projection.
 
-Unlike the particle- and mesh-based solvers, the Stable Fluid solver does not track Lagrangian entities. It solves everything on a uniform grid whose resolution you set through `SFOptions.res`, and gas is injected by velocity jets that you register on the solver.
-
-## Supported materials
-
-| Material | Description |
-|----------|-------------|
-| `SF.Smoke` | Smoke advected on the stable-fluid grid |
+Unlike the particle- and mesh-based solvers, the Stable Fluid solver does not track Lagrangian entities. It solves everything on a uniform grid whose resolution you set through `SFOptions.res`, and gas is injected by velocity jets that you register on the solver. It simulates the `SF.Smoke` material; see {doc}`/api_reference/material/sf`.
 
 ## Usage
 
@@ -40,17 +34,7 @@ for _ in range(200):
 
 See `examples/smoke.py` for the full runnable example, including the jet class and the code that writes the density field to images.
 
-## Configuration
-
-Key options in `SFOptions`:
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `res` | int | 128 | Grid resolution per axis; the grid is `res x res x res`. |
-| `solver_iters` | int | 500 | Jacobi iterations for the pressure projection. |
-| `decay` | float | 0.99 | Per-step decay applied to the advected scalar (density) field. |
-| `inlet_s` | float | 400.0 | Impulse scale applied at the jets when injecting momentum. |
-| `dt` | float | inherited | Substep duration in seconds. Inherits from `SimOptions` if not set. |
+Configure the grid resolution and projection through `SFOptions`; see {doc}`/api_reference/options/simulator_coupler_and_solver_options/sf_options` for the full option set.
 
 ## Behavior and guarantees
 
@@ -60,4 +44,5 @@ Key options in `SFOptions`:
 
 ## See also
 
+- {doc}`/api_reference/material/sf`: the smoke material simulated by this solver.
 - {doc}`/api_reference/options/simulator_coupler_and_solver_options/sf_options`: full options.

--- a/source/api_reference/engine/solvers/sph_solver.md
+++ b/source/api_reference/engine/solvers/sph_solver.md
@@ -1,25 +1,10 @@
-# SPHSolver
+# `SPHSolver`
 
-The `SPHSolver` implements Smoothed Particle Hydrodynamics for liquid simulation.
-
-## Overview
-
-SPH approximates fluid dynamics with particles:
-
-- Pressure forces from local density.
-- Viscosity forces from velocity differences.
-- Surface tension.
-- Free-surface handling.
-
-Two pressure solvers are available through `pressure_solver`: weakly compressible SPH (`"WCSPH"`, the default) and divergence-free SPH (`"DFSPH"`).
-
-## Supported materials
-
-| Material | Description |
-|----------|-------------|
-| `SPH.Liquid` | General liquid |
+The `SPHSolver` implements Smoothed Particle Hydrodynamics for liquid simulation. It approximates fluid dynamics with particles, deriving pressure forces from local density, viscosity forces from velocity differences, and surface tension, with free-surface handling. Two pressure solvers are available through `pressure_solver`: weakly compressible SPH (`"WCSPH"`, the default) and divergence-free SPH (`"DFSPH"`). It simulates the `SPH.Liquid` material; see {doc}`/api_reference/material/sph`.
 
 ## Usage
+
+The solver activates when the scene contains an SPH entity. Configure it through `SPHOptions`; see {doc}`/api_reference/options/simulator_coupler_and_solver_options/sph_options` for the full option set.
 
 ```python
 import genesis as gs
@@ -51,32 +36,8 @@ for i in range(1000):
     scene.step()
 ```
 
-## Configuration
-
-Key options in `SPHOptions`:
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `lower_bound` | tuple | `(-100, -100, 0)` | Lower corner of the simulation domain. |
-| `upper_bound` | tuple | `(100, 100, 100)` | Upper corner of the simulation domain. |
-| `particle_size` | float | `0.02` | Particle diameter in meters. |
-| `pressure_solver` | str | `"WCSPH"` | Pressure solver: `"WCSPH"` or `"DFSPH"`. |
-| `dt` | float | inherited | Substep duration in seconds. Inherits from `SimOptions` if not set. |
-
-## Material parameters
-
-`SPH.Liquid` parameters and typical values:
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `rho` | `1000.0` | Rest density in kg/m³ (water). |
-| `stiffness` | `50000.0` | State stiffness in N/m²; controls how pressure rises with compression. |
-| `exponent` | `7.0` | State exponent; controls how nonlinearly pressure scales with density. |
-| `mu` | `0.005` | Dynamic viscosity. |
-| `gamma` | `0.01` | Surface tension. |
-
 ## See also
 
 - {doc}`/api_reference/entity/sph_entity`: SPHEntity.
-- {doc}`/api_reference/material/sph/index`: SPH materials.
+- {doc}`/api_reference/material/sph`: SPH materials.
 - {doc}`/api_reference/options/simulator_coupler_and_solver_options/sph_options`: full options.

--- a/source/api_reference/engine/solvers/tool_solver.md
+++ b/source/api_reference/engine/solvers/tool_solver.md
@@ -1,18 +1,10 @@
-# ToolSolver
+# `ToolSolver`
 
-The `ToolSolver` handles kinematic tools and end-effectors that drive other physics objects through one-way coupling.
-
-## Overview
-
-The tool solver provides:
-
-- Kinematic motion control of a tool entity.
-- One-way coupling into the soft solvers (MPM, FEM, PBD, SPH).
-- Tool-object interaction without internal tool dynamics.
-
-A ToolEntity has no internal dynamics and is built from a single mesh. It is a temporary workaround for differentiable rigid-soft interaction and will be removed once the RigidSolver supports differentiability directly.
+The `ToolSolver` handles kinematic tools and end-effectors that drive other physics objects through one-way coupling into the soft solvers (MPM, FEM, PBD, SPH). A `ToolEntity` has no internal dynamics and is built from a single mesh. It is a temporary workaround for differentiable rigid-soft interaction and will be removed once the `RigidSolver` supports differentiability directly.
 
 ## Usage
+
+The solver activates when the scene contains a tool entity. Configure it through `ToolOptions`; see {doc}`/api_reference/options/simulator_coupler_and_solver_options/tool_options` for the full option set.
 
 ```python
 import genesis as gs
@@ -37,26 +29,6 @@ for i in range(1000):
     scene.step()
 ```
 
-## Configuration
-
-Key options in `ToolOptions`:
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `dt` | float | inherited | Substep duration in seconds. Inherits from `SimOptions` if not set. |
-| `floor_height` | float | inherited | Floor height in meters. Inherits from `SimOptions` if not set. |
-
-## Material parameters
-
-`gs.materials.Tool` parameters:
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `friction` | `0.0` | Friction coefficient. |
-| `coup_softness` | `0.01` | Softness of the coupling interaction. |
-| `collision` | `True` | Whether the tool participates in collision. |
-| `sdf_res` | `128` | Resolution of the signed-distance-field grid. |
-
 ## Interaction with other solvers
 
 Tools couple one way into the soft solvers:
@@ -70,5 +42,6 @@ The coupling is handled automatically by the coupler.
 
 ## See also
 
+- {doc}`/api_reference/material/tool`: the tool material and its parameters.
 - {doc}`/api_reference/engine/couplers/index`: coupling with other solvers.
 - {doc}`/api_reference/options/simulator_coupler_and_solver_options/tool_options`: full options.

--- a/source/api_reference/engine/states/index.md
+++ b/source/api_reference/engine/states/index.md
@@ -92,5 +92,5 @@ loss.backward()
 
 ## See also
 
-- {doc}`/api_reference/differentiation/index` - differentiable simulation
-- {doc}`/api_reference/scene/scene` - scene state methods (`get_state`, `reset`)
+- {doc}`/api_reference/differentiation/index`: differentiable simulation
+- {doc}`/api_reference/scene/scene`: scene state methods (`get_state`, `reset`)

--- a/source/api_reference/engine/states/index.md
+++ b/source/api_reference/engine/states/index.md
@@ -1,20 +1,16 @@
 # States
 
-States in Genesis World hold the runtime data for physics simulation, including positions, velocities, forces, and other solver-specific variables.
+A state holds the runtime data of a simulation: positions, velocities, forces, and the solver-specific variables that evolve each step. `scene.get_state()` returns a `SimState`, an aggregate snapshot of the whole scene that holds one per-solver state for each active solver:
 
-## Overview
+- **RigidSolverState:** link poses, joint positions and velocities.
+- **MPMSolverState:** particle positions, velocities, deformation gradients.
+- **FEMSolverState:** node positions, velocities.
+- **PBDSolverState:** particle positions, velocities.
+- **SPHSolverState:** particle positions, velocities, densities.
 
-`scene.get_state()` returns a `SimState`, the aggregate snapshot for the whole scene. It holds one per-solver state for each solver present:
+## Reading state
 
-- **RigidSolverState**: link poses, joint positions and velocities
-- **MPMSolverState**: particle positions, velocities, deformation gradients
-- **FEMSolverState**: node positions, velocities
-- **PBDSolverState**: particle positions, velocities
-- **SPHSolverState**: particle positions, velocities, densities
-
-## Accessing state
-
-States are accessed through entities or the simulator:
+Read state through the entity you added, rather than through the aggregate snapshot. After `scene.build()`, call the getters directly:
 
 ```python
 import genesis as gs
@@ -24,73 +20,51 @@ scene = gs.Scene()
 robot = scene.add_entity(gs.morphs.URDF(file="robot.urdf"))
 scene.build()
 
-# Access via entity
-positions = robot.get_qpos()      # Joint positions
-velocities = robot.get_qvel()     # Joint velocities
-link_pos = robot.get_link("ee").get_pos()
-
-# Full state access (advanced)
-rigid_solver = scene.sim.rigid_solver
-# ... direct solver state access
+qpos = robot.get_qpos()                 # ([n_envs,] n_dofs)
+qvel = robot.get_qvel()                 # ([n_envs,] n_dofs)
+ee_pos = robot.get_link("ee").get_pos()  # ([n_envs,] 3)
 ```
 
-## State for parallel environments
-
-With `n_envs > 1`, states are batched:
+The returned tensors follow the batched-optional shape convention: the leading environment dimension is present when the scene is built with multiple environments and absent otherwise. Pass `envs_idx` to read a subset:
 
 ```python
 scene.build(n_envs=16)
-
-# Batched state access
-positions = robot.get_qpos()  # Shape: (n_envs, n_dofs)
-
-# Per-environment access
-positions = robot.get_qpos(envs_idx=[0, 5, 10])
+qpos = robot.get_qpos()                  # (16, n_dofs)
+qpos = robot.get_qpos(envs_idx=[0, 5, 10])  # (3, n_dofs)
 ```
 
-## State management
+See {doc}`/user_guide/configuration/conventions` for the full shape and dtype conventions.
 
-### Saving state
+## Saving and restoring
+
+`scene.get_state()` returns a `SimState` snapshot of the whole scene:
 
 ```python
-state = scene.get_state()  # a SimState snapshot of the whole scene
+state = scene.get_state()
 ```
 
-### Restoring state
-
-The scene has no `set_state`. Restore a saved `SimState` by passing it to `scene.reset`, which resets the scene to that state and registers it as the new initial state:
+The scene has no `set_state`. Restore a snapshot by passing it to `scene.reset`, which resets the scene to that state and registers it as the new initial state:
 
 ```python
-scene.reset(state=state)
+scene.reset(state=state)   # restore a saved snapshot
+scene.reset()              # reset all environments to the initial state
+scene.reset(envs_idx=[0, 1, 2])  # reset only the given environments
 ```
 
-Individual solvers and entities expose their own `set_state` for finer-grained restoration (for example, `scene.sim.rigid_solver.set_state(...)`).
-
-### Resetting
-
-```python
-scene.reset()  # reset all environments to the initial state
-scene.reset(envs_idx=[0, 1, 2])  # reset specific environments
-```
+Individual solvers and entities expose their own `set_state` for finer-grained restoration, for example `scene.sim.rigid_solver.set_state(...)`.
 
 ## Gradient tracking
 
-For differentiable simulation:
+When the scene is built for differentiable simulation, state tensors track gradients, so a loss computed from them can be backpropagated:
 
 ```python
-scene = gs.Scene(
-    sim_options=gs.options.SimOptions(
-        requires_grad=True,
-    ),
-)
-
-# States now track gradients
-scene.step()
+scene = gs.Scene(sim_options=gs.options.SimOptions(requires_grad=True))
+# ... build, step ...
 loss = compute_loss(robot.get_qpos())
 loss.backward()
 ```
 
 ## See also
 
-- {doc}`/api_reference/differentiation/index`: differentiable simulation
-- {doc}`/api_reference/scene/scene`: scene state methods (`get_state`, `reset`)
+- {doc}`/api_reference/differentiation/index`: differentiable simulation.
+- {doc}`/api_reference/scene/scene`: the `get_state` and `reset` methods on the scene.

--- a/source/api_reference/entity/drone_entity.md
+++ b/source/api_reference/entity/drone_entity.md
@@ -1,8 +1,8 @@
 # `DroneEntity`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.entities.drone_entity.DroneEntity
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/emitter.md
+++ b/source/api_reference/entity/emitter.md
@@ -1,8 +1,8 @@
 # `Emitter`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.entities.emitter.Emitter
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/fem_entity.md
+++ b/source/api_reference/entity/fem_entity.md
@@ -1,8 +1,8 @@
 # `FEMEntity`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.entities.fem_entity.FEMEntity
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/hybrid_entity.md
+++ b/source/api_reference/entity/hybrid_entity.md
@@ -1,8 +1,8 @@
 # `HybridEntity`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.entities.hybrid_entity.HybridEntity
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/mpm_entity.md
+++ b/source/api_reference/entity/mpm_entity.md
@@ -1,8 +1,8 @@
 # `MPMEntity`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.entities.mpm_entity.MPMEntity
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/pbd_entity/index.md
+++ b/source/api_reference/entity/pbd_entity/index.md
@@ -1,4 +1,6 @@
-# PBDEntity
+# PBD entities
+
+The Position Based Dynamics solver simulates several entity types, one per PBD material: cloth, elastic volumes, and free particles. The concrete class depends on the material you assign.
 
 ```{toctree}
 pbd_particle

--- a/source/api_reference/entity/pbd_entity/pbd_2d.md
+++ b/source/api_reference/entity/pbd_entity/pbd_2d.md
@@ -1,8 +1,8 @@
 # `PBD2DEntity`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.entities.pbd_entity.PBD2DEntity
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/pbd_entity/pbd_3d.md
+++ b/source/api_reference/entity/pbd_entity/pbd_3d.md
@@ -1,8 +1,8 @@
 # `PBD3DEntity`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.entities.pbd_entity.PBD3DEntity
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/pbd_entity/pbd_free_particle.md
+++ b/source/api_reference/entity/pbd_entity/pbd_free_particle.md
@@ -1,8 +1,8 @@
 # `PBDFreeParticleEntity`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.entities.pbd_entity.PBDFreeParticleEntity
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/pbd_entity/pbd_particle.md
+++ b/source/api_reference/entity/pbd_entity/pbd_particle.md
@@ -1,8 +1,8 @@
 # `PBDParticleEntity`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.entities.pbd_entity.PBDParticleEntity
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/pbd_entity/pbd_tet.md
+++ b/source/api_reference/entity/pbd_entity/pbd_tet.md
@@ -1,8 +1,8 @@
 # `PBDTetEntity`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.entities.pbd_entity.PBDTetEntity
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/rigid_entity/index.md
+++ b/source/api_reference/entity/rigid_entity/index.md
@@ -1,4 +1,6 @@
-# RigidEntity
+# Rigid entity
+
+A `RigidEntity` is an articulated rigid body: a robot, mechanism, or rigid object simulated by the rigid solver. It is built from links connected by joints, each link carrying collision and visual geometry. These pages document the entity and its parts.
 
 ```{toctree}
 rigid_entity

--- a/source/api_reference/entity/rigid_entity/rigid_entity.md
+++ b/source/api_reference/entity/rigid_entity/rigid_entity.md
@@ -1,8 +1,8 @@
 # `RigidEntity`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.entities.rigid_entity.rigid_entity.RigidEntity
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/rigid_entity/rigid_geom.md
+++ b/source/api_reference/entity/rigid_entity/rigid_geom.md
@@ -1,8 +1,8 @@
 # `RigidGeom`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.entities.rigid_entity.rigid_geom.RigidGeom
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/rigid_entity/rigid_joint.md
+++ b/source/api_reference/entity/rigid_entity/rigid_joint.md
@@ -1,8 +1,8 @@
 # `RigidJoint`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.entities.rigid_entity.rigid_joint.RigidJoint
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/rigid_entity/rigid_link.md
+++ b/source/api_reference/entity/rigid_entity/rigid_link.md
@@ -1,8 +1,8 @@
 # `RigidLink`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.entities.rigid_entity.rigid_link.RigidLink
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/rigid_entity/rigid_visgeom.md
+++ b/source/api_reference/entity/rigid_entity/rigid_visgeom.md
@@ -1,8 +1,8 @@
 # `RigidVisGeom`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.entities.rigid_entity.rigid_geom.RigidVisGeom
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/sf_entity.md
+++ b/source/api_reference/entity/sf_entity.md
@@ -5,6 +5,6 @@ The particle entity backing Stable Fluid smoke, created from a {py:class}`gs.mat
 ```{eval-rst}
 .. autoclass:: genesis.engine.entities.sf_entity.SFParticleEntity
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/sph_entity.md
+++ b/source/api_reference/entity/sph_entity.md
@@ -1,8 +1,8 @@
 # `SPHEntity`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.entities.sph_entity.SPHEntity
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/entity/tool_entity.md
+++ b/source/api_reference/entity/tool_entity.md
@@ -5,6 +5,6 @@ A kinematically-scripted collider created from a {py:class}`gs.materials.Tool <g
 ```{eval-rst}
 .. autoclass:: genesis.engine.entities.tool_entity.tool_entity.ToolEntity
     :members:
-    :show-inheritance:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/material/fem/cloth.md
+++ b/source/api_reference/material/fem/cloth.md
@@ -1,10 +1,7 @@
-# Cloth
+# `gs.materials.FEM.Cloth`
 
 `gs.materials.FEM.Cloth` simulates thin shells such as cloth and fabric using a shell-based FEM formulation in the IPC backend. Use it for garments, flags, and membranes where bending and stretching of a thin surface matter.
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.FEM.cloth.Cloth
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/fem/elastic.md
+++ b/source/api_reference/material/fem/elastic.md
@@ -1,8 +1,5 @@
 # `gs.materials.FEM.Elastic`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.FEM.elastic.Elastic
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/fem/index.md
+++ b/source/api_reference/material/fem/index.md
@@ -1,5 +1,7 @@
 # FEM
 
+The Finite Element Method simulates deformable solids on tetrahedral meshes. Each material below selects a constitutive model for the FEM solver.
+
 ```{toctree}
 cloth
 elastic

--- a/source/api_reference/material/fem/muscle.md
+++ b/source/api_reference/material/fem/muscle.md
@@ -1,8 +1,5 @@
 # `gs.materials.FEM.Muscle`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.FEM.muscle.Muscle
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/hybrid.md
+++ b/source/api_reference/material/hybrid.md
@@ -1,8 +1,5 @@
 # `gs.materials.Hybrid`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.hybrid.Hybrid
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/index.md
+++ b/source/api_reference/material/index.md
@@ -25,8 +25,8 @@ rigid
 mpm/index
 fem/index
 pbd/index
-sph/index
-sf/index
+sph
+sf
 hybrid
 tool
 kinematic

--- a/source/api_reference/material/kinematic.md
+++ b/source/api_reference/material/kinematic.md
@@ -1,10 +1,7 @@
-# Kinematic
+# `gs.materials.Kinematic`
 
 `gs.materials.Kinematic` marks an entity as a visualization-only ghost or reference. Kinematic entities are rendered but take no part in physics, collision, or constraint solving, so use them for targets, markers, and other overlays that should never affect the simulation.
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.kinematic.Kinematic
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/mpm/elastic.md
+++ b/source/api_reference/material/mpm/elastic.md
@@ -1,8 +1,5 @@
 # `gs.materials.MPM.Elastic`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.MPM.elastic.Elastic
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/mpm/elasto_plastic.md
+++ b/source/api_reference/material/mpm/elasto_plastic.md
@@ -1,8 +1,5 @@
 # `gs.materials.MPM.ElastoPlastic`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.MPM.elasto_plastic.ElastoPlastic
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/mpm/index.md
+++ b/source/api_reference/material/mpm/index.md
@@ -1,5 +1,7 @@
 # MPM
 
+The Material Point Method simulates elastic and plastic solids, granular media, and fluids. Each material below selects a constitutive model for the MPM solver.
+
 ```{toctree}
 elastic
 elasto_plastic

--- a/source/api_reference/material/mpm/liquid.md
+++ b/source/api_reference/material/mpm/liquid.md
@@ -1,8 +1,5 @@
 # `gs.materials.MPM.Liquid`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.MPM.liquid.Liquid
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/mpm/muscle.md
+++ b/source/api_reference/material/mpm/muscle.md
@@ -1,8 +1,5 @@
 # `gs.materials.MPM.Muscle`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.MPM.muscle.Muscle
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/mpm/sand.md
+++ b/source/api_reference/material/mpm/sand.md
@@ -1,8 +1,5 @@
 # `gs.materials.MPM.Sand`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.MPM.sand.Sand
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/mpm/snow.md
+++ b/source/api_reference/material/mpm/snow.md
@@ -1,8 +1,5 @@
 # `gs.materials.MPM.Snow`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.MPM.snow.Snow
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/pbd/cloth.md
+++ b/source/api_reference/material/pbd/cloth.md
@@ -1,8 +1,5 @@
 # `gs.materials.PBD.Cloth`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.PBD.cloth.Cloth
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/pbd/elastic.md
+++ b/source/api_reference/material/pbd/elastic.md
@@ -1,8 +1,5 @@
 # `gs.materials.PBD.Elastic`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.PBD.elastic.Elastic
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/pbd/index.md
+++ b/source/api_reference/material/pbd/index.md
@@ -1,5 +1,7 @@
 # PBD
 
+Position Based Dynamics simulates cloth, soft bodies, and particle fluids. Each material below configures a constraint model for the PBD solver.
+
 ```{toctree}
 elastic
 cloth

--- a/source/api_reference/material/pbd/liquid.md
+++ b/source/api_reference/material/pbd/liquid.md
@@ -1,8 +1,5 @@
 # `gs.materials.PBD.Liquid`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.PBD.liquid.Liquid
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/pbd/particle.md
+++ b/source/api_reference/material/pbd/particle.md
@@ -1,8 +1,5 @@
 # `gs.materials.PBD.Particle`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.PBD.particle.Particle
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/rigid.md
+++ b/source/api_reference/material/rigid.md
@@ -1,8 +1,5 @@
 # `gs.materials.Rigid`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.rigid.Rigid
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/sf.md
+++ b/source/api_reference/material/sf.md
@@ -1,0 +1,7 @@
+# `gs.materials.SF.Smoke`
+
+`gs.materials.SF.Smoke` drives an entity through the Stable Fluid solver as a gaseous medium such as smoke or hot gas. Use it for grid-based fluid effects where you want advected density and velocity fields rather than particles. It is the only material in the SF family.
+
+```{eval-rst}
+.. autoclass:: genesis.engine.materials.SF.smoke.Smoke
+```

--- a/source/api_reference/material/sf/index.md
+++ b/source/api_reference/material/sf/index.md
@@ -1,5 +1,0 @@
-# SF
-
-```{toctree}
-smoke
-```

--- a/source/api_reference/material/sf/smoke.md
+++ b/source/api_reference/material/sf/smoke.md
@@ -1,10 +1,7 @@
-# Smoke
+# `gs.materials.SF.Smoke`
 
 `gs.materials.SF.Smoke` drives an entity through the Stable Fluid solver as a gaseous medium such as smoke or hot gas. Use it for grid-based fluid effects where you want advected density and velocity fields rather than particles.
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.SF.smoke.Smoke
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/sf/smoke.md
+++ b/source/api_reference/material/sf/smoke.md
@@ -1,7 +1,0 @@
-# `gs.materials.SF.Smoke`
-
-`gs.materials.SF.Smoke` drives an entity through the Stable Fluid solver as a gaseous medium such as smoke or hot gas. Use it for grid-based fluid effects where you want advected density and velocity fields rather than particles.
-
-```{eval-rst}
-.. autoclass:: genesis.engine.materials.SF.smoke.Smoke
-```

--- a/source/api_reference/material/sph.md
+++ b/source/api_reference/material/sph.md
@@ -1,0 +1,7 @@
+# `gs.materials.SPH.Liquid`
+
+`gs.materials.SPH.Liquid` drives an entity through the Smoothed Particle Hydrodynamics solver as a liquid, such as water. Use it for free-surface fluids simulated with particles. It is the only material in the SPH family.
+
+```{eval-rst}
+.. autoclass:: genesis.engine.materials.SPH.liquid.Liquid
+```

--- a/source/api_reference/material/sph/index.md
+++ b/source/api_reference/material/sph/index.md
@@ -1,5 +1,0 @@
-# SPH
-
-```{toctree}
-liquid
-```

--- a/source/api_reference/material/sph/liquid.md
+++ b/source/api_reference/material/sph/liquid.md
@@ -1,8 +1,5 @@
 # `gs.materials.SPH.Liquid`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.SPH.liquid.Liquid
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/material/sph/liquid.md
+++ b/source/api_reference/material/sph/liquid.md
@@ -1,5 +1,0 @@
-# `gs.materials.SPH.Liquid`
-
-```{eval-rst}
-.. autoclass:: genesis.engine.materials.SPH.liquid.Liquid
-```

--- a/source/api_reference/material/tool.md
+++ b/source/api_reference/material/tool.md
@@ -1,10 +1,7 @@
-# Tool
+# `gs.materials.Tool`
 
 `gs.materials.Tool` marks an entity as a kinematically scripted collider that couples to soft and particle media. Use it for actuators, graspers, or moving boundaries whose motion you drive directly while they push on MPM, PBD, or other deformable entities.
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.materials.tool.Tool
-    :members:
-    :show-inheritance:
-    :undoc-members:
 ```

--- a/source/api_reference/options/misc/coacd_options.md
+++ b/source/api_reference/options/misc/coacd_options.md
@@ -1,4 +1,4 @@
-# CoACD options
+# `gs.options.CoacdOptions`
 
 Configures approximate convex decomposition of meshes via [CoACD](https://github.com/SarahWeiii/CoACD), which splits a concave mesh into convex parts for collision handling.
 

--- a/source/api_reference/options/misc/foam_options.md
+++ b/source/api_reference/options/misc/foam_options.md
@@ -1,4 +1,4 @@
-# Foam options
+# `gs.options.FoamOptions`
 
 Configures foam particle generation, used to render spray and bubble effects on top of a fluid simulation.
 

--- a/source/api_reference/options/misc/profiling_options.md
+++ b/source/api_reference/options/misc/profiling_options.md
@@ -1,4 +1,4 @@
-# Profiling options
+# `gs.options.ProfilingOptions`
 
 Configures runtime profiling, including whether to report the per-step frame rate and how that moving average is smoothed.
 

--- a/source/api_reference/options/morph/file_morph/drone.md
+++ b/source/api_reference/options/morph/file_morph/drone.md
@@ -1,4 +1,5 @@
 # `gs.morphs.Drone`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.morphs.Drone
 ```

--- a/source/api_reference/options/morph/file_morph/file_morph.md
+++ b/source/api_reference/options/morph/file_morph/file_morph.md
@@ -1,4 +1,5 @@
 # `gs.morphs.FileMorph`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.morphs.FileMorph
 ```

--- a/source/api_reference/options/morph/file_morph/index.md
+++ b/source/api_reference/options/morph/file_morph/index.md
@@ -1,11 +1,14 @@
 # FileMorph
 
+File morphs load geometry and pose from an external file: a mesh, a URDF or MJCF robot description, a USD stage, a terrain heightfield, or a drone model.
+
 ```{toctree}
 :titlesonly:
 :maxdepth: 1
 
 file_morph
 mesh
+mesh_set
 urdf
 mjcf
 usd

--- a/source/api_reference/options/morph/file_morph/mesh.md
+++ b/source/api_reference/options/morph/file_morph/mesh.md
@@ -1,4 +1,5 @@
 # `gs.morphs.Mesh`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.morphs.Mesh
 ```

--- a/source/api_reference/options/morph/file_morph/mesh_set.md
+++ b/source/api_reference/options/morph/file_morph/mesh_set.md
@@ -1,0 +1,7 @@
+# `gs.morphs.MeshSet`
+
+`gs.morphs.MeshSet` loads several mesh files as a single entity, each placed with its own position and orientation. Use it to assemble a compound object from multiple meshes through one morph.
+
+```{eval-rst}
+.. autoclass:: genesis.options.morphs.MeshSet
+```

--- a/source/api_reference/options/morph/file_morph/mjcf.md
+++ b/source/api_reference/options/morph/file_morph/mjcf.md
@@ -1,4 +1,5 @@
 # `gs.morphs.MJCF`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.morphs.MJCF
 ```

--- a/source/api_reference/options/morph/file_morph/terrain.md
+++ b/source/api_reference/options/morph/file_morph/terrain.md
@@ -1,4 +1,5 @@
 # `gs.morphs.Terrain`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.morphs.Terrain
 ```

--- a/source/api_reference/options/morph/file_morph/urdf.md
+++ b/source/api_reference/options/morph/file_morph/urdf.md
@@ -1,4 +1,5 @@
 # `gs.morphs.URDF`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.morphs.URDF
 ```

--- a/source/api_reference/options/morph/file_morph/usd.md
+++ b/source/api_reference/options/morph/file_morph/usd.md
@@ -1,8 +1,7 @@
-# USD morph
+# `gs.morphs.USD`
 
 Loads geometry from a Universal Scene Description (USD) file. Use it to bring USD stages into a scene via `scene.add_stage`, with control over convexification, decimation, and convex decomposition of the imported meshes.
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.options.morphs.USD
-    :show-inheritance:
 ```

--- a/source/api_reference/options/morph/index.md
+++ b/source/api_reference/options/morph/index.md
@@ -8,4 +8,5 @@ A morph in Genesis World is a hybrid concept, encapsulating both the `geometry` 
 morph
 primitive/index
 file_morph/index
+nowhere
 ```

--- a/source/api_reference/options/morph/morph.md
+++ b/source/api_reference/options/morph/morph.md
@@ -1,4 +1,5 @@
 # `gs.morphs.Morph`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.morphs.Morph
 ```

--- a/source/api_reference/options/morph/nowhere.md
+++ b/source/api_reference/options/morph/nowhere.md
@@ -1,0 +1,7 @@
+# `gs.morphs.Nowhere`
+
+`gs.morphs.Nowhere` is a placeholder morph that carries no initial geometry. It is used for particle entities that start empty and are populated at runtime, for example the target of an {doc}`emitter </api_reference/entity/emitter>`.
+
+```{eval-rst}
+.. autoclass:: genesis.options.morphs.Nowhere
+```

--- a/source/api_reference/options/morph/primitive/box.md
+++ b/source/api_reference/options/morph/primitive/box.md
@@ -1,4 +1,5 @@
 # `gs.morphs.Box`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.morphs.Box
 ```

--- a/source/api_reference/options/morph/primitive/cylinder.md
+++ b/source/api_reference/options/morph/primitive/cylinder.md
@@ -1,4 +1,5 @@
 # `gs.morphs.Cylinder`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.morphs.Cylinder
 ```

--- a/source/api_reference/options/morph/primitive/index.md
+++ b/source/api_reference/options/morph/primitive/index.md
@@ -1,5 +1,7 @@
 # Primitive
 
+Primitive morphs are parametric shapes: box, sphere, cylinder, and plane. Use them for quick geometry without an external mesh file.
+
 ```{toctree}
 :titlesonly:
 :maxdepth: 1

--- a/source/api_reference/options/morph/primitive/plane.md
+++ b/source/api_reference/options/morph/primitive/plane.md
@@ -1,4 +1,5 @@
 # `gs.morphs.Plane`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.morphs.Plane
 ```

--- a/source/api_reference/options/morph/primitive/primitive.md
+++ b/source/api_reference/options/morph/primitive/primitive.md
@@ -1,4 +1,5 @@
 # `gs.morphs.Primitive`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.morphs.Primitive
 ```

--- a/source/api_reference/options/morph/primitive/sphere.md
+++ b/source/api_reference/options/morph/primitive/sphere.md
@@ -1,4 +1,5 @@
 # `gs.morphs.Sphere`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.morphs.Sphere
 ```

--- a/source/api_reference/options/options.md
+++ b/source/api_reference/options/options.md
@@ -1,4 +1,5 @@
 # `gs.options.Options`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.options.Options
 ```

--- a/source/api_reference/options/simulator_coupler_and_solver_options/coupler_options.md
+++ b/source/api_reference/options/simulator_coupler_and_solver_options/coupler_options.md
@@ -1,4 +1,5 @@
 # `gs.options.BaseCouplerOptions`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.solvers.BaseCouplerOptions
 ```

--- a/source/api_reference/options/simulator_coupler_and_solver_options/fem_options.md
+++ b/source/api_reference/options/simulator_coupler_and_solver_options/fem_options.md
@@ -1,4 +1,5 @@
 # `gs.options.FEMOptions`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.solvers.FEMOptions
 ```

--- a/source/api_reference/options/simulator_coupler_and_solver_options/ipc_coupler_options.md
+++ b/source/api_reference/options/simulator_coupler_and_solver_options/ipc_coupler_options.md
@@ -1,8 +1,7 @@
-# IPC coupler options
+# `gs.options.IPCCouplerOptions`
 
 Configures the inter-solver coupler built on Incremental Potential Contact (IPC), including its Newton solver settings. Time step, gravity, and differentiable simulation mode are inherited from `SimOptions` and should not be set here.
 
 ```{eval-rst}
 .. autoclass:: genesis.options.solvers.IPCCouplerOptions
-   :show-inheritance:
 ```

--- a/source/api_reference/options/simulator_coupler_and_solver_options/kinematic_options.md
+++ b/source/api_reference/options/simulator_coupler_and_solver_options/kinematic_options.md
@@ -1,4 +1,4 @@
-# Kinematic solver options
+# `gs.options.KinematicOptions`
 
 Configures the kinematic solver, a lightweight solver for ghost or reference entities that only computes forward kinematics for visualization. It performs no collision detection, physics integration, or constraint solving.
 

--- a/source/api_reference/options/simulator_coupler_and_solver_options/legacy_coupler_options.md
+++ b/source/api_reference/options/simulator_coupler_and_solver_options/legacy_coupler_options.md
@@ -1,8 +1,7 @@
-# Legacy coupler options
+# `gs.options.LegacyCouplerOptions`
 
 Configures the legacy inter-solver coupler, which toggles pairwise coupling between the rigid, MPM, SPH, PBD, and FEM solvers.
 
 ```{eval-rst}
 .. autoclass:: genesis.options.solvers.LegacyCouplerOptions
-   :show-inheritance:
 ```

--- a/source/api_reference/options/simulator_coupler_and_solver_options/mpm_options.md
+++ b/source/api_reference/options/simulator_coupler_and_solver_options/mpm_options.md
@@ -1,4 +1,5 @@
 # `gs.options.MPMOptions`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.solvers.MPMOptions
 ```

--- a/source/api_reference/options/simulator_coupler_and_solver_options/pbd_options.md
+++ b/source/api_reference/options/simulator_coupler_and_solver_options/pbd_options.md
@@ -1,4 +1,5 @@
 # `gs.options.PBDOptions`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.solvers.PBDOptions
 ```

--- a/source/api_reference/options/simulator_coupler_and_solver_options/rigid_options.md
+++ b/source/api_reference/options/simulator_coupler_and_solver_options/rigid_options.md
@@ -1,4 +1,5 @@
 # `gs.options.RigidOptions`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.solvers.RigidOptions
 ```

--- a/source/api_reference/options/simulator_coupler_and_solver_options/sap_coupler_options.md
+++ b/source/api_reference/options/simulator_coupler_and_solver_options/sap_coupler_options.md
@@ -1,8 +1,7 @@
-# SAP coupler options
+# `gs.options.SAPCouplerOptions`
 
 Configures the inter-solver coupler built on the Semi-Analytic Primal (SAP) contact solver, including its solver iteration counts and convergence tolerances.
 
 ```{eval-rst}
 .. autoclass:: genesis.options.solvers.SAPCouplerOptions
-   :show-inheritance:
 ```

--- a/source/api_reference/options/simulator_coupler_and_solver_options/sf_options.md
+++ b/source/api_reference/options/simulator_coupler_and_solver_options/sf_options.md
@@ -1,4 +1,5 @@
 # `gs.options.SFOptions`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.solvers.SFOptions
 ```

--- a/source/api_reference/options/simulator_coupler_and_solver_options/sim_options.md
+++ b/source/api_reference/options/simulator_coupler_and_solver_options/sim_options.md
@@ -1,4 +1,5 @@
 # `gs.options.SimOptions`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.solvers.SimOptions
 ```

--- a/source/api_reference/options/simulator_coupler_and_solver_options/sph_options.md
+++ b/source/api_reference/options/simulator_coupler_and_solver_options/sph_options.md
@@ -1,4 +1,5 @@
 # `gs.options.SPHOptions`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.solvers.SPHOptions
 ```

--- a/source/api_reference/options/simulator_coupler_and_solver_options/tool_options.md
+++ b/source/api_reference/options/simulator_coupler_and_solver_options/tool_options.md
@@ -1,4 +1,5 @@
 # `gs.options.ToolOptions`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.solvers.ToolOptions
 ```

--- a/source/api_reference/options/surface/emission.md
+++ b/source/api_reference/options/surface/emission.md
@@ -1,0 +1,7 @@
+# `gs.surfaces.Emission`
+
+`gs.surfaces.Emission` makes a surface emit light, so the entity glows rather than only reflecting incident light. Emissive surfaces are rendered by the `RayTracer` backend.
+
+```{eval-rst}
+.. autoclass:: genesis.options.surfaces.Emission
+```

--- a/source/api_reference/options/surface/emission/emission.md
+++ b/source/api_reference/options/surface/emission/emission.md
@@ -1,5 +1,0 @@
-# `gs.surfaces.Emission`
-
-```{eval-rst}
-.. autoclass:: genesis.options.surfaces.Emission
-```

--- a/source/api_reference/options/surface/emission/emission.md
+++ b/source/api_reference/options/surface/emission/emission.md
@@ -1,4 +1,5 @@
 # `gs.surfaces.Emission`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.surfaces.Emission
 ```

--- a/source/api_reference/options/surface/emission/index.md
+++ b/source/api_reference/options/surface/emission/index.md
@@ -1,7 +1,0 @@
-# Emission
-
-```{toctree}
-:maxdepth: 2
-
-emission
-```

--- a/source/api_reference/options/surface/glass/glass.md
+++ b/source/api_reference/options/surface/glass/glass.md
@@ -1,4 +1,5 @@
 # `gs.surfaces.Glass`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.surfaces.Glass
 ```

--- a/source/api_reference/options/surface/glass/index.md
+++ b/source/api_reference/options/surface/glass/index.md
@@ -1,5 +1,7 @@
 # Glass
 
+Glass surfaces render as transmissive dielectrics. Use `gs.surfaces.Glass` for general transparent materials and `gs.surfaces.Water` for water.
+
 ```{toctree}
 :maxdepth: 2
 

--- a/source/api_reference/options/surface/glass/water.md
+++ b/source/api_reference/options/surface/glass/water.md
@@ -1,4 +1,5 @@
 # `gs.surfaces.Water`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.surfaces.Water
 ```

--- a/source/api_reference/options/surface/index.md
+++ b/source/api_reference/options/surface/index.md
@@ -1,5 +1,5 @@
 # Surface
-A ``Surface`` object encapsulates all visual information used for rendering an entity or its sub-components (links, geoms, etc.)
+A `Surface` object encapsulates all visual information used for rendering an entity or its sub-components (links, geoms, etc.)
 The surface contains different types textures: diffuse_texture, specular_texture, roughness_texture, metallic_texture, transmission_texture, normal_texture, and emissive_texture. Each one of them is a `gs.textures.Texture` object.
 
 :::{note}

--- a/source/api_reference/options/surface/index.md
+++ b/source/api_reference/options/surface/index.md
@@ -13,6 +13,6 @@ Most advanced surface types are only supported by cameras using the `RayTracer` 
 surface
 plastic/index
 metal/index
-emission/index
+emission
 glass/index
 ```

--- a/source/api_reference/options/surface/metal/aluminium.md
+++ b/source/api_reference/options/surface/metal/aluminium.md
@@ -1,4 +1,5 @@
 # `gs.surfaces.Aluminium`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.surfaces.Aluminium
 ```

--- a/source/api_reference/options/surface/metal/copper.md
+++ b/source/api_reference/options/surface/metal/copper.md
@@ -1,4 +1,5 @@
 # `gs.surfaces.Copper`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.surfaces.Copper
 ```

--- a/source/api_reference/options/surface/metal/gold.md
+++ b/source/api_reference/options/surface/metal/gold.md
@@ -1,4 +1,5 @@
 # `gs.surfaces.Gold`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.surfaces.Gold
 ```

--- a/source/api_reference/options/surface/metal/index.md
+++ b/source/api_reference/options/surface/metal/index.md
@@ -1,5 +1,7 @@
 # Metal
 
+Metal surfaces render with a metallic BSDF. Use a preset alloy (iron, aluminium, copper, gold) or the base `gs.surfaces.Metal` for a custom metal.
+
 ```{toctree}
 :maxdepth: 2
 

--- a/source/api_reference/options/surface/metal/iron.md
+++ b/source/api_reference/options/surface/metal/iron.md
@@ -1,4 +1,5 @@
 # `gs.surfaces.Iron`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.surfaces.Iron
 ```

--- a/source/api_reference/options/surface/metal/metal.md
+++ b/source/api_reference/options/surface/metal/metal.md
@@ -1,4 +1,5 @@
 # `gs.surfaces.Metal`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.surfaces.Metal
 ```

--- a/source/api_reference/options/surface/plastic/bsdf.md
+++ b/source/api_reference/options/surface/plastic/bsdf.md
@@ -1,8 +1,7 @@
-# BSDF surface
+# `gs.surfaces.BSDF`
 
 A Disney principled BSDF surface, exposing the full set of physically based rendering parameters. `gs.surfaces.Default` is a subclass of `BSDF` with no added parameters, so the substantive PBR controls documented here, such as `specular_trans`, `diffuse_trans`, and `metallic_texture`, apply equally to both.
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.options.surfaces.BSDF
-    :show-inheritance:
 ```

--- a/source/api_reference/options/surface/plastic/collision.md
+++ b/source/api_reference/options/surface/plastic/collision.md
@@ -1,5 +1,5 @@
 # `gs.surfaces.Collision`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.surfaces.Collision
-    :show-inheritance:
 ```

--- a/source/api_reference/options/surface/plastic/default.md
+++ b/source/api_reference/options/surface/plastic/default.md
@@ -1,5 +1,5 @@
 # `gs.surfaces.Default`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.surfaces.Default
-    :show-inheritance:
 ```

--- a/source/api_reference/options/surface/plastic/index.md
+++ b/source/api_reference/options/surface/plastic/index.md
@@ -1,5 +1,7 @@
 # Plastic
 
+Plastic surfaces render with a dielectric BSDF, from rough to smooth to reflective. Use them for non-metallic materials such as painted or coated objects.
+
 ```{toctree}
 :maxdepth: 2
 

--- a/source/api_reference/options/surface/plastic/plastic.md
+++ b/source/api_reference/options/surface/plastic/plastic.md
@@ -1,5 +1,5 @@
 # `gs.surfaces.Plastic`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.surfaces.Plastic
-    :show-inheritance:
 ```

--- a/source/api_reference/options/surface/plastic/reflective.md
+++ b/source/api_reference/options/surface/plastic/reflective.md
@@ -1,5 +1,5 @@
 # `gs.surfaces.Reflective`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.surfaces.Reflective
-    :show-inheritance:
 ```

--- a/source/api_reference/options/surface/plastic/rough.md
+++ b/source/api_reference/options/surface/plastic/rough.md
@@ -1,5 +1,5 @@
 # `gs.surfaces.Rough`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.surfaces.Rough
-    :show-inheritance:
 ```

--- a/source/api_reference/options/surface/plastic/smooth.md
+++ b/source/api_reference/options/surface/plastic/smooth.md
@@ -1,5 +1,5 @@
 # `gs.surfaces.Smooth`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.surfaces.Smooth
-    :show-inheritance:
 ```

--- a/source/api_reference/options/surface/surface.md
+++ b/source/api_reference/options/surface/surface.md
@@ -1,4 +1,5 @@
 # `gs.surfaces.Surface`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.surfaces.Surface
 ```

--- a/source/api_reference/options/texture/batch_texture.md
+++ b/source/api_reference/options/texture/batch_texture.md
@@ -1,9 +1,7 @@
-# Batch texture
+# `gs.textures.BatchTexture`
 
 A batch of textures used for batch rendering, where each environment can be assigned its own texture. Construct one directly from a list of textures, or use the `from_images` and `from_colors` factory methods to build a batch from per-environment images or colors.
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.options.textures.BatchTexture
-    :show-inheritance:
-    :members:
 ```

--- a/source/api_reference/options/texture/color_texture.md
+++ b/source/api_reference/options/texture/color_texture.md
@@ -1,5 +1,5 @@
 # `gs.textures.ColorTexture`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.textures.ColorTexture
-    :show-inheritance:
 ```

--- a/source/api_reference/options/texture/image_texture.md
+++ b/source/api_reference/options/texture/image_texture.md
@@ -1,5 +1,5 @@
 # `gs.textures.ImageTexture`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.textures.ImageTexture
-    :show-inheritance:
 ```

--- a/source/api_reference/options/texture/index.md
+++ b/source/api_reference/options/texture/index.md
@@ -1,5 +1,7 @@
 # Texture
 
+A texture supplies the per-point values a surface samples, such as its color or an image map. Assign textures to a surface's channels: diffuse, specular, roughness, metallic, transmission, normal, and emissive.
+
 ```{toctree}
 :maxdepth: 2
 

--- a/source/api_reference/options/texture/texture.md
+++ b/source/api_reference/options/texture/texture.md
@@ -1,5 +1,5 @@
 # `gs.textures.Texture`
-```{eval-rst}  
+
+```{eval-rst}
 .. autoclass:: genesis.options.textures.Texture
-    :show-inheritance:
 ```

--- a/source/api_reference/recording/file_writers.md
+++ b/source/api_reference/recording/file_writers.md
@@ -110,9 +110,9 @@ scene.stop_recording()
 
 ```{eval-rst}
 .. automodule:: genesis.recorders.file_writers
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/recording/file_writers.md
+++ b/source/api_reference/recording/file_writers.md
@@ -1,121 +1,32 @@
 # File writers
 
-Genesis World provides file writers for exporting simulation data to various formats.
+A file writer records sampled data to disk. Pass one as the `rec_options` argument of `scene.start_recording`, and the recorder manager samples your data function on schedule and writes each sample to the file. See {doc}`index` for the recording workflow and the shared options (`hz`, `buffer_size`, `save_on_reset`) that every writer inherits.
 
-## Available writers
+## `gs.recorders.NPZFile`
 
-| Writer | Format | Description |
-|--------|--------|-------------|
-| `CSVFileWriter` | `.csv` | Tabular data export |
-| `NPZFileWriter` | `.npz` | NumPy compressed arrays |
-| `VideoFileWriter` | `.mp4` | Video from camera/viewer |
-
-## CSVFile
-
-Export data as comma-separated values:
-
-```python
-import genesis as gs
-
-gs.init()
-scene = gs.Scene()
-robot = scene.add_entity(gs.morphs.URDF(file="robot.urdf"))
-scene.build()
-
-# Record joint positions to CSV
-scene.start_recording(
-    data_func=lambda: {
-        "q0": robot.get_qpos()[0],
-        "q1": robot.get_qpos()[1],
-        "q2": robot.get_qpos()[2],
-    },
-    rec_options=gs.recorders.CSVFile(
-        filename="joint_data.csv",
-        hz=100,
-    ),
-)
-
-for i in range(1000):
-    scene.step()
-scene.stop_recording()
-```
-
-## NPZFile
-
-Export data as NumPy compressed archive:
-
-```python
-scene.start_recording(
-    data_func=lambda: {
-        "pos": robot.get_pos(),
-        "qpos": robot.get_qpos(),
-        "qvel": robot.get_qvel(),
-    },
-    rec_options=gs.recorders.NPZFile(
-        filename="trajectory.npz",
-        hz=50,
-    ),
-)
-
-# ... simulation ...
-scene.stop_recording()
-
-# Load recorded data
-import numpy as np
-data = np.load("trajectory.npz")
-positions = data["pos"]
-```
-
-## VideoFile
-
-Record video from cameras or viewer:
-
-```python
-cam = scene.add_camera(
-    res=(1280, 720),
-    pos=(3, 0, 2),
-    lookat=(0, 0, 0.5),
-)
-
-scene.start_recording(
-    data_func=lambda: cam.render(rgb=True)[0],
-    rec_options=gs.recorders.VideoFile(
-        filename="simulation.mp4",
-    ),
-)
-
-for i in range(300):
-    scene.step()
-scene.stop_recording()
-```
-
-## Configuration options
-
-### Common options
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `filename` | str | Required | Output file path |
-| `hz` | float | None | Recording frequency |
-| `async_mode` | bool | False | Background processing |
-
-### VideoFileWriter options
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `fps` | int | 30 | Video frame rate |
-| `codec` | str | "libx264" | Video codec |
-
-## API reference
+Writes samples to a NumPy `.npz` archive. Best for numeric arrays you load back with `numpy.load`.
 
 ```{eval-rst}
-.. automodule:: genesis.recorders.file_writers
-    :members:
-    :undoc-members:
-    :show-inheritance:
+.. autoclass:: genesis.options.recorders.NPZFile
+```
+
+## `gs.recorders.CSVFile`
+
+Writes samples as rows in a `.csv` file. Best for scalar or low-dimensional data you inspect in a spreadsheet.
+
+```{eval-rst}
+.. autoclass:: genesis.options.recorders.CSVFile
+```
+
+## `gs.recorders.VideoFile`
+
+Encodes a stream of image frames to a video file. Pair it with a data function that returns a rendered frame.
+
+```{eval-rst}
+.. autoclass:: genesis.options.recorders.VideoFile
 ```
 
 ## See also
 
-- {doc}`index` - Recording overview
-- {doc}`plotters` - Real-time visualization
+- {doc}`index`: the recording workflow and shared recorder options.
+- {doc}`plotters`: live plotting instead of writing to a file.

--- a/source/api_reference/recording/plotters.md
+++ b/source/api_reference/recording/plotters.md
@@ -76,9 +76,9 @@ You can start multiple recorders for different data streams by calling `start_re
 
 ```{eval-rst}
 .. automodule:: genesis.recorders.plotters
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/recording/plotters.md
+++ b/source/api_reference/recording/plotters.md
@@ -1,87 +1,42 @@
 # Plotters
 
-Genesis World provides real-time plotting recorders for visualizing simulation data during execution.
+A plotter visualizes sampled data live as the scene steps, and can save the animation. Pass one as the `rec_options` argument of `scene.start_recording`. See {doc}`index` for the recording workflow and the shared options (`hz`, `buffer_size`) that every plotter inherits.
 
-## Available plotters
+A data function that returns a `dict` becomes one labeled subplot per key.
 
-| Plotter | Description |
-|---------|-------------|
-| `MPLLinePlot` | Matplotlib line plot (time series) |
-| `MPLImagePlot` | Matplotlib image display |
+## `gs.recorders.PyQtLinePlot`
 
-## MPLLinePlot
-
-Real-time line plots using Matplotlib:
-
-```python
-import genesis as gs
-
-gs.init()
-scene = gs.Scene()
-robot = scene.add_entity(gs.morphs.URDF(file="robot.urdf"))
-scene.build()
-
-# Plot joint positions over time
-scene.start_recording(
-    data_func=lambda: robot.get_qpos()[:3],  # First 3 joints
-    rec_options=gs.recorders.MPLLinePlot(
-        title="Joint Positions",
-    ),
-)
-
-for i in range(1000):
-    scene.step()
-scene.stop_recording()
-```
-
-### Configuration
-
-```python
-gs.recorders.MPLLinePlot(
-    title="Plot Title",           # Plot title
-    hz=30,                        # Update rate
-)
-```
-
-## MPLImagePlot
-
-Display images in real-time:
-
-```python
-cam = scene.add_camera(res=(320, 240), pos=(3, 0, 2), lookat=(0, 0, 0.5))
-
-scene.start_recording(
-    data_func=lambda: cam.render(rgb=True),
-    rec_options=gs.recorders.MPLImagePlot(
-        title="Camera View",
-    ),
-)
-
-for i in range(500):
-    scene.step()
-scene.stop_recording()
-```
-
-## Multiple recorders
-
-You can start multiple recorders for different data streams by calling `start_recording` multiple times or using the RecorderManager directly.
-
-## Performance tips
-
-1. **Reduce update rate**: Use lower `hz` for complex plots
-2. **Limit data points**: Use smaller `window_size`
-3. **Use async mode**: Enable `async_mode=True` for background updates
-
-## API reference
+Live line plot backed by PyQtGraph. The fastest option for high-rate time-series data, at the cost of a PyQt dependency.
 
 ```{eval-rst}
-.. automodule:: genesis.recorders.plotters
-    :members:
-    :undoc-members:
-    :show-inheritance:
+.. autoclass:: genesis.options.recorders.PyQtLinePlot
+```
+
+## `gs.recorders.MPLLinePlot`
+
+Live line plot backed by Matplotlib. Use it for time-series data when a Matplotlib figure is preferred.
+
+```{eval-rst}
+.. autoclass:: genesis.options.recorders.MPLLinePlot
+```
+
+## `gs.recorders.MPLImagePlot`
+
+Displays a 2D array as a live image or heatmap, for example a camera frame or a sensor grid.
+
+```{eval-rst}
+.. autoclass:: genesis.options.recorders.MPLImagePlot
+```
+
+## `gs.recorders.MPLVectorFieldPlot`
+
+Draws a live vector field (quiver plot) from an array of 2D or 3D vectors.
+
+```{eval-rst}
+.. autoclass:: genesis.options.recorders.MPLVectorFieldPlot
 ```
 
 ## See also
 
-- {doc}`index` - Recording overview
-- {doc}`file_writers` - File export
+- {doc}`index`: the recording workflow and shared recorder options.
+- {doc}`file_writers`: writing data to a file instead of plotting.

--- a/source/api_reference/recording/recorder.md
+++ b/source/api_reference/recording/recorder.md
@@ -1,4 +1,4 @@
-# Recorder
+# `Recorder`
 
 The `Recorder` class is the base class for all recording functionality in Genesis. It provides the interface for capturing and processing simulation data.
 
@@ -53,9 +53,9 @@ class MyRecorder(Recorder):
 
 ```{eval-rst}
 .. autoclass:: genesis.recorders.base_recorder.Recorder
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/recording/recorder.md
+++ b/source/api_reference/recording/recorder.md
@@ -60,6 +60,6 @@ class MyRecorder(Recorder):
 
 ## See also
 
-- {doc}`recorder_manager` - Managing multiple recorders
-- {doc}`file_writers` - Built-in file writers
-- {doc}`plotters` - Built-in plotters
+- {doc}`recorder_manager`: Managing multiple recorders
+- {doc}`file_writers`: Built-in file writers
+- {doc}`plotters`: Built-in plotters

--- a/source/api_reference/recording/recorder_manager.md
+++ b/source/api_reference/recording/recorder_manager.md
@@ -80,7 +80,7 @@ cam.stop_recording(save_to_filename="video.mp4", fps=60)
 
 ## See also
 
-- {doc}`/user_guide/sensing/recorders` - task-oriented guide to recording
-- {doc}`recorder` - base recorder class
+- {doc}`/user_guide/sensing/recorders`: task-oriented guide to recording
+- {doc}`recorder`: base recorder class
 - {doc}`file_writers` and {doc}`plotters` - the recorder options you pass to `start_recording`
-- {doc}`/api_reference/scene/scene` - `scene.start_recording` and `scene.stop_recording`
+- {doc}`/api_reference/scene/scene`: `scene.start_recording` and `scene.stop_recording`

--- a/source/api_reference/recording/recorder_manager.md
+++ b/source/api_reference/recording/recorder_manager.md
@@ -1,4 +1,4 @@
-# RecorderManager
+# `RecorderManager`
 
 The `RecorderManager` is the per-scene component that drives every recorder: it holds the registered recorders, samples their data functions as the scene steps, and flushes and closes them when recording stops. You do not construct or call it directly. You register recorders through `scene.start_recording` (or `sensor.start_recording`) and stop them through `scene.stop_recording`; the manager does the rest.
 
@@ -73,9 +73,9 @@ cam.stop_recording(save_to_filename="video.mp4", fps=60)
 
 ```{eval-rst}
 .. autoclass:: genesis.recorders.recorder_manager.RecorderManager
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/scene/force_field.md
+++ b/source/api_reference/scene/force_field.md
@@ -1,7 +1,8 @@
 # Force fields
 
-```{eval-rst}  
+```{eval-rst}
 .. automodule:: genesis.engine.force_fields
     :members:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/scene/force_field.md
+++ b/source/api_reference/scene/force_field.md
@@ -1,4 +1,4 @@
-# Force fields
+# `ForceField`
 
 ```{eval-rst}
 .. automodule:: genesis.engine.force_fields

--- a/source/api_reference/scene/mesh.md
+++ b/source/api_reference/scene/mesh.md
@@ -1,7 +1,8 @@
 # `Mesh`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.mesh.Mesh
     :members:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/scene/scene.md
+++ b/source/api_reference/scene/scene.md
@@ -1,7 +1,8 @@
 # `Scene`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.scene.Scene
     :members:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/scene/simulator.md
+++ b/source/api_reference/scene/simulator.md
@@ -1,7 +1,8 @@
 # `Simulator`
 
-```{eval-rst}  
+```{eval-rst}
 .. autoclass:: genesis.engine.simulator.Simulator
     :members:
     :undoc-members:
+    :show-inheritance:
 ```

--- a/source/api_reference/sensor/camera.md
+++ b/source/api_reference/sensor/camera.md
@@ -48,39 +48,33 @@ Use the rasterizer for fast RGB with no special setup. Use the raytracer for pho
 
 ```{eval-rst}
 .. autoclass:: genesis.options.sensors.camera.RasterizerCameraOptions
-   :members:
-   :show-inheritance:
 
 .. autoclass:: genesis.engine.sensors.camera.RasterizerCameraSensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## Raytracer camera
 
 ```{eval-rst}
 .. autoclass:: genesis.options.sensors.camera.RaytracerCameraOptions
-   :members:
-   :show-inheritance:
 
 .. autoclass:: genesis.engine.sensors.camera.RaytracerCameraSensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## Batch renderer camera
 
 ```{eval-rst}
 .. autoclass:: genesis.options.sensors.camera.BatchRendererCameraOptions
-   :members:
-   :show-inheritance:
 
 .. autoclass:: genesis.engine.sensors.camera.BatchRendererCameraSensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/sensor/contact.md
+++ b/source/api_reference/sensor/contact.md
@@ -35,22 +35,6 @@ for i in range(1000):
     print(f"Contact force: {force}")
 ```
 
-### Configuration
-
-```python
-gs.sensors.ContactForce(
-    entity_idx=robot.idx,           # Global entity index
-    link_idx_local=finger.idx_local, # Local link index
-    pos_offset=(0.0, 0.0, 0.0),    # Position offset from link frame
-    euler_offset=(0.0, 0.0, 0.0),  # Rotation offset (degrees)
-    min_force=0.0,                  # Min detectable absolute force per axis (below → 0)
-    max_force=float("inf"),         # Max output absolute force per axis (above → clipped)
-    noise=0.0,                      # White noise std
-    bias=0.0,                       # Constant additive bias
-    draw_debug=True,
-)
-```
-
 ### Output format
 
 `read()` returns a plain `torch.Tensor` (float32):
@@ -58,6 +42,8 @@ gs.sensors.ContactForce(
 | Shape | Description |
 |-------|-------------|
 | `([n_envs,] 3)` | Total contact force in local link frame (Newtons) |
+
+The options passed to `gs.sensors.ContactForce` (offsets, force clamping, noise) are documented in the reference below.
 
 ## ContactSensor
 
@@ -94,7 +80,11 @@ in_contact = contact.read()  # ([n_envs,] 1) boolean tensor
 
 ## API reference
 
-### ContactForceSensor
+### `gs.sensors.ContactForce`
+
+```{eval-rst}
+.. autoclass:: genesis.options.sensors.options.ContactForce
+```
 
 ```{eval-rst}
 .. autoclass:: genesis.engine.sensors.contact_force.ContactForceSensor
@@ -103,7 +93,11 @@ in_contact = contact.read()  # ([n_envs,] 1) boolean tensor
     :show-inheritance:
 ```
 
-### ContactSensor
+### `gs.sensors.Contact`
+
+```{eval-rst}
+.. autoclass:: genesis.options.sensors.options.Contact
+```
 
 ```{eval-rst}
 .. autoclass:: genesis.engine.sensors.contact_force.ContactSensor
@@ -114,5 +108,5 @@ in_contact = contact.read()  # ([n_envs,] 1) boolean tensor
 
 ## See also
 
-- {doc}`index` - Sensor overview
-- {doc}`/api_reference/entity/rigid_entity/index` - RigidEntity and links
+- {doc}`index`: Sensor overview
+- {doc}`/api_reference/entity/rigid_entity/index`: RigidEntity and links

--- a/source/api_reference/sensor/contact.md
+++ b/source/api_reference/sensor/contact.md
@@ -98,18 +98,18 @@ in_contact = contact.read()  # ([n_envs,] 1) boolean tensor
 
 ```{eval-rst}
 .. autoclass:: genesis.engine.sensors.contact_force.ContactForceSensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ### ContactSensor
 
 ```{eval-rst}
 .. autoclass:: genesis.engine.sensors.contact_force.ContactSensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/sensor/imu.md
+++ b/source/api_reference/sensor/imu.md
@@ -150,9 +150,9 @@ for i in range(1000):
 
 ```{eval-rst}
 .. autoclass:: genesis.engine.sensors.imu.IMUSensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/sensor/imu.md
+++ b/source/api_reference/sensor/imu.md
@@ -42,44 +42,7 @@ for i in range(1000):
     mag = data.mag        # ([n_envs,] 3) magnetic field in Tesla
 ```
 
-## Configuration
-
-```python
-gs.sensors.IMU(
-    # Attachment (inherited from RigidSensorOptionsMixin)
-    entity_idx=robot.idx,             # Global entity index
-    link_idx_local=base.idx_local,    # Local link index
-    pos_offset=(0.0, 0.0, 0.0),      # Position offset from link frame
-    euler_offset=(0.0, 0.0, 0.0),    # Rotation offset from link frame (degrees)
-
-    # Accelerometer parameters
-    acc_noise=(0.01, 0.01, 0.01),              # White noise std per axis (m/s^2)
-    acc_random_walk=(0.001, 0.001, 0.001),     # Bias drift std per axis (m/s^3)
-    acc_bias=(0.0, 0.0, 0.0),                  # Constant additive bias per axis
-    acc_cross_axis_coupling=0.0,               # Cross-axis misalignment
-    acc_resolution=0.0,                        # Measurement resolution (0 = no quantization)
-
-    # Gyroscope parameters
-    gyro_noise=(0.01, 0.01, 0.01),             # White noise std per axis (rad/s)
-    gyro_random_walk=(0.001, 0.001, 0.001),    # Bias drift std per axis (rad/s^2)
-    gyro_bias=(0.0, 0.0, 0.0),                # Constant additive bias per axis
-    gyro_cross_axis_coupling=0.0,              # Cross-axis misalignment
-    gyro_resolution=0.0,                       # Measurement resolution (0 = no quantization)
-
-    # Magnetometer parameters
-    mag_noise=(0.0, 0.0, 0.0),                # White noise std per axis
-    mag_random_walk=(0.0, 0.0, 0.0),          # Bias drift std per axis
-    mag_bias=(0.0, 0.0, 0.0),                 # Constant additive bias per axis
-    mag_cross_axis_coupling=0.0,               # Cross-axis misalignment
-    mag_resolution=0.0,                        # Measurement resolution (0 = no quantization)
-
-    # Timing
-    delay=0.0,                                 # Read delay in seconds
-    jitter=0.0,                                # Random delay jitter in seconds
-
-    draw_debug=True,
-)
-```
+The options passed to `gs.sensors.IMU` (attachment offsets and the accelerometer, gyroscope, and magnetometer noise models) are documented in the reference below.
 
 ## Output format
 
@@ -148,6 +111,12 @@ for i in range(1000):
 
 ## API reference
 
+### `gs.sensors.IMU`
+
+```{eval-rst}
+.. autoclass:: genesis.options.sensors.options.IMU
+```
+
 ```{eval-rst}
 .. autoclass:: genesis.engine.sensors.imu.IMUSensor
     :members:
@@ -157,5 +126,5 @@ for i in range(1000):
 
 ## See also
 
-- {doc}`index` - Sensor overview
-- {doc}`contact` - Contact force sensing
+- {doc}`index`: Sensor overview
+- {doc}`contact`: Contact force sensing

--- a/source/api_reference/sensor/other.md
+++ b/source/api_reference/sensor/other.md
@@ -10,14 +10,11 @@ Reports the nearest distance from each probe point to the mesh surfaces of a set
 
 ```{eval-rst}
 .. autoclass:: genesis.options.sensors.options.SurfaceDistanceProbe
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
 .. autoclass:: genesis.engine.sensors.surface_distance_probe.SurfaceDistanceProbeSensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## TemperatureGrid
@@ -28,18 +25,13 @@ Material properties are supplied through a `properties_dict` mapping a global ri
 
 ```{eval-rst}
 .. autoclass:: genesis.options.sensors.options.TemperatureProperties
-   :members:
-   :undoc-members:
 
 .. autoclass:: genesis.options.sensors.options.TemperatureGrid
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
 .. autoclass:: genesis.engine.sensors.temperature.TemperatureGridSensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## JointTorque
@@ -48,14 +40,11 @@ Measures the generalized effort delivered at each selected actuator's output sha
 
 ```{eval-rst}
 .. autoclass:: genesis.options.sensors.options.JointTorque
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
 .. autoclass:: genesis.engine.sensors.joint_torque.JointTorqueSensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/sensor/other.md
+++ b/source/api_reference/sensor/other.md
@@ -49,6 +49,6 @@ Measures the generalized effort delivered at each selected actuator's output sha
 
 ## See also
 
-- {doc}`index` - Sensor overview
-- {doc}`contact` - Contact and contact-force sensing
-- {doc}`raycaster` - Ray-based distance measurement
+- {doc}`index`: Sensor overview
+- {doc}`contact`: Contact and contact-force sensing
+- {doc}`raycaster`: Ray-based distance measurement

--- a/source/api_reference/sensor/raycaster.md
+++ b/source/api_reference/sensor/raycaster.md
@@ -142,7 +142,13 @@ depth = depth_cam.read_image()  # shape ([n_envs,] 72, 96), meters
 
 ## API reference
 
-### RaycasterSensor
+### `gs.sensors.Raycaster`
+
+Also available as `gs.sensors.Lidar`.
+
+```{eval-rst}
+.. autoclass:: genesis.options.sensors.options.Raycaster
+```
 
 ```{eval-rst}
 .. autoclass:: genesis.engine.sensors.raycaster.RaycasterSensor
@@ -151,7 +157,11 @@ depth = depth_cam.read_image()  # shape ([n_envs,] 72, 96), meters
     :show-inheritance:
 ```
 
-### DepthCameraSensor
+### `gs.sensors.DepthCamera`
+
+```{eval-rst}
+.. autoclass:: genesis.options.sensors.options.DepthCamera
+```
 
 ```{eval-rst}
 .. autoclass:: genesis.engine.sensors.depth_camera.DepthCameraSensor
@@ -176,5 +186,5 @@ A pattern is a local description of the rays: it fixes a start point and a unit 
 
 ## See also
 
-- {doc}`index` - Sensor overview
-- {doc}`camera` - Visual sensing
+- {doc}`index`: Sensor overview
+- {doc}`camera`: Visual sensing

--- a/source/api_reference/sensor/raycaster.md
+++ b/source/api_reference/sensor/raycaster.md
@@ -146,18 +146,18 @@ depth = depth_cam.read_image()  # shape ([n_envs,] 72, 96), meters
 
 ```{eval-rst}
 .. autoclass:: genesis.engine.sensors.raycaster.RaycasterSensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ### DepthCameraSensor
 
 ```{eval-rst}
 .. autoclass:: genesis.engine.sensors.depth_camera.DepthCameraSensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ### Ray patterns
@@ -166,24 +166,12 @@ A pattern is a local description of the rays: it fixes a start point and a unit 
 
 ```{eval-rst}
 .. autoclass:: genesis.options.sensors.raycaster.RaycastPattern
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
 .. autoclass:: genesis.options.sensors.raycaster.SphericalPattern
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
 .. autoclass:: genesis.options.sensors.raycaster.GridPattern
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
 .. autoclass:: genesis.options.sensors.raycaster.DepthCameraPattern
-   :members:
-   :undoc-members:
-   :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/sensor/tactile.md
+++ b/source/api_reference/sensor/tactile.md
@@ -86,6 +86,6 @@ Estimates per-taxel force and torque from a point cloud sampled on the tracked m
 
 ## See also
 
-- {doc}`index` - Sensor overview
-- {doc}`/user_guide/sensing/contact_and_tactile` - Usage, probe layout, and force models
-- {doc}`contact` - Solver-based contact and contact-force sensing
+- {doc}`index`: Sensor overview
+- {doc}`/user_guide/sensing/contact_and_tactile`: Usage, probe layout, and force models
+- {doc}`contact`: Solver-based contact and contact-force sensing

--- a/source/api_reference/sensor/tactile.md
+++ b/source/api_reference/sensor/tactile.md
@@ -15,14 +15,11 @@ Thresholds each probe's penetration depth into a per-probe boolean contact flag.
 
 ```{eval-rst}
 .. autoclass:: genesis.options.sensors.tactile.ContactProbe
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
 .. autoclass:: genesis.engine.sensors.kinematic_tactile.ContactProbeSensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## ContactDepthProbe
@@ -31,14 +28,11 @@ Reports the penetration depth at each probe, in meters.
 
 ```{eval-rst}
 .. autoclass:: genesis.options.sensors.tactile.ContactDepthProbe
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
 .. autoclass:: genesis.engine.sensors.kinematic_tactile.ContactDepthProbeSensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## KinematicTaxel
@@ -47,18 +41,16 @@ Adds a spring-damper force model on top of the depth query, estimating per-taxel
 
 ```{eval-rst}
 .. autoclass:: genesis.options.sensors.tactile.KinematicTaxel
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
 .. autoclass:: genesis.engine.sensors.kinematic_tactile.KinematicTaxelSensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 .. autoclass:: genesis.engine.sensors.kinematic_tactile.KinematicTaxelReturnType
-   :members:
-   :undoc-members:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## ElastomerTaxel
@@ -67,14 +59,11 @@ Models a soft tactile skin, reporting a 3D marker displacement per probe from in
 
 ```{eval-rst}
 .. autoclass:: genesis.options.sensors.tactile.ElastomerTaxel
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
 .. autoclass:: genesis.engine.sensors.point_cloud_tactile.ElastomerTaxelSensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## ProximityTaxel
@@ -83,18 +72,16 @@ Estimates per-taxel force and torque from a point cloud sampled on the tracked m
 
 ```{eval-rst}
 .. autoclass:: genesis.options.sensors.tactile.ProximityTaxel
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
 .. autoclass:: genesis.engine.sensors.point_cloud_tactile.ProximityTaxelSensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 .. autoclass:: genesis.engine.sensors.point_cloud_tactile.ProximityTaxelReturnType
-   :members:
-   :undoc-members:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/utilities/constants.md
+++ b/source/api_reference/utilities/constants.md
@@ -8,15 +8,17 @@ Genesis World defines several enums and constants for physics simulation configu
 import genesis as gs
 
 # Available backends
-gs.backend.cpu      # CPU backend
-gs.backend.gpu      # Auto-select GPU (CUDA on Linux, Metal on MacOS)
-gs.backend.cuda     # NVIDIA CUDA
-gs.backend.metal    # Apple Metal
-gs.backend.amdgpu   # AMD ROCm (HIP)
+gs.cpu      # CPU backend
+gs.gpu      # auto-select GPU (CUDA on Linux, Metal on macOS)
+gs.cuda     # NVIDIA CUDA
+gs.metal    # Apple Metal
+gs.amdgpu   # AMD ROCm (HIP)
 
 # Usage
 gs.init(backend=gs.gpu)
 ```
+
+After `gs.init()`, `gs.backend` holds the backend that was actually selected.
 
 ## Joint types
 

--- a/source/api_reference/utilities/constants.md
+++ b/source/api_reference/utilities/constants.md
@@ -114,5 +114,5 @@ gs.INACTIVE  # Entity is inactive (0)
 
 ## See also
 
-- {doc}`device` - Device and platform utilities
-- {doc}`/api_reference/options/index` - Configuration options
+- {doc}`device`: Device and platform utilities
+- {doc}`/api_reference/options/index`: Configuration options

--- a/source/api_reference/utilities/device.md
+++ b/source/api_reference/utilities/device.md
@@ -76,5 +76,5 @@ gs.tc_int    # PyTorch int dtype
 
 ## See also
 
-- {doc}`constants` - Backend enums
-- {doc}`tensor_utils` - Tensor operations
+- {doc}`constants`: Backend enums
+- {doc}`tensor_utils`: Tensor operations

--- a/source/api_reference/utilities/file_io.md
+++ b/source/api_reference/utilities/file_io.md
@@ -113,5 +113,5 @@ plane = scene.add_entity(gs.morphs.Plane())
 
 ## See also
 
-- {doc}`/api_reference/options/morph/file_morph/index` - File-based morphs
-- {doc}`/api_reference/entity/index` - Entity loading
+- {doc}`/api_reference/options/morph/file_morph/index`: File-based morphs
+- {doc}`/api_reference/entity/index`: Entity loading

--- a/source/api_reference/utilities/tensor_utils.md
+++ b/source/api_reference/utilities/tensor_utils.md
@@ -96,5 +96,5 @@ some_positions = robot.get_qpos(envs_idx=[0, 5, 10])
 
 ## See also
 
-- {doc}`device` - Device configuration
-- {doc}`/api_reference/engine/states/index` - State management
+- {doc}`device`: Device configuration
+- {doc}`/api_reference/engine/states/index`: State management

--- a/source/api_reference/visualization/camera.md
+++ b/source/api_reference/visualization/camera.md
@@ -1,4 +1,4 @@
-# Camera
+# `Camera`
 
 The visualization camera renders a scene off-screen to images: color, depth, segmentation, and surface normals. Add one with `scene.add_camera(...)` and read frames with `cam.render(...)`. It renders through the scene's {doc}`renderer <renderers/index>`, needs no display, and works headless. It can move, follow an entity, and record video.
 
@@ -29,9 +29,9 @@ Do not confuse this with the {doc}`camera sensor </api_reference/sensor/camera>`
 
 ```{eval-rst}
 .. autoclass:: genesis.vis.camera.Camera
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/visualization/lights.md
+++ b/source/api_reference/visualization/lights.md
@@ -34,7 +34,6 @@ A spherical area light for the `RayTracer` renderer. Add one or more to a scene 
 
 ```{eval-rst}
 .. autoclass:: genesis.options.renderers.SphereLight
-    :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/visualization/lights.md
+++ b/source/api_reference/visualization/lights.md
@@ -3,7 +3,7 @@
 Lights illuminate a rendered scene. How you add them depends on the backend:
 
 - **Rasterizer (and the viewer):** lights come from the `lights` list on `gs.options.VisOptions`, using the light classes in `gs.options.vis`. With no configuration the scene gets a single directional light, so it is lit out of the box. Ambient fill is set separately through `VisOptions.ambient_light`.
-- **RayTracer:** there are no light objects. Lights are entities with an `Emission` {doc}`surface </api_reference/options/surface/emission/index>`, plus optional `SphereLight` area lights (below).
+- **RayTracer:** there are no light objects. Lights are entities with an `Emission` {doc}`surface </api_reference/options/surface/emission>`, plus optional `SphereLight` area lights (below).
 - **BatchRenderer:** lights are added at runtime with `scene.add_light(...)`; see {doc}`renderers/batch_renderer`.
 
 ```python
@@ -28,6 +28,34 @@ scene = gs.Scene(
 
 For the task-oriented explanation, see {doc}`/user_guide/rendering/index`.
 
+## Rasterizer lights
+
+These classes populate the `lights` list on `gs.options.VisOptions` and light the rasterizer and the viewer.
+
+### `gs.options.vis.DirectionalLight`
+
+A light with parallel rays and no position, like the sun. The scene's default light is one of these.
+
+```{eval-rst}
+.. autoclass:: genesis.options.vis.DirectionalLight
+```
+
+### `gs.options.vis.PointLight`
+
+A light that emits from a point in space, falling off with distance.
+
+```{eval-rst}
+.. autoclass:: genesis.options.vis.PointLight
+```
+
+### `gs.options.vis.AmbientLight`
+
+A uniform fill light with no direction, applied everywhere so shadows are not pure black. Ambient fill can also be set directly through `VisOptions.ambient_light`.
+
+```{eval-rst}
+.. autoclass:: genesis.options.vis.AmbientLight
+```
+
 ## SphereLight
 
 A spherical area light for the `RayTracer` renderer. Add one or more to a scene to illuminate it, controlling position, color, intensity, and radius. Color values are not restricted to `[0, 1]`, so they can express HDR intensities.
@@ -40,4 +68,4 @@ A spherical area light for the `RayTracer` renderer. Add one or more to a scene 
 
 - {doc}`viewer`: `VisOptions`, which holds the rasterizer light list
 - {doc}`renderers/raytracer`: photorealistic rendering
-- {doc}`/api_reference/options/surface/emission/index`: emissive surfaces
+- {doc}`/api_reference/options/surface/emission`: emissive surfaces

--- a/source/api_reference/visualization/renderers/batch_renderer.md
+++ b/source/api_reference/visualization/renderers/batch_renderer.md
@@ -1,4 +1,4 @@
-# BatchRenderer
+# `gs.renderers.BatchRenderer`
 
 A high-throughput renderer that renders many parallel environments together on the GPU, for large-scale data collection and reinforcement-learning observation generation. Enable it with `gs.Scene(renderer=gs.renderers.BatchRenderer(use_rasterizer=True))`; set `use_rasterizer=False` to path-trace instead. It requires the `gs-madrona` package.
 
@@ -29,9 +29,9 @@ scene.add_light(
 
 ```{eval-rst}
 .. autoclass:: genesis.vis.batch_renderer.BatchRenderer
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/visualization/renderers/rasterizer.md
+++ b/source/api_reference/visualization/renderers/rasterizer.md
@@ -1,4 +1,4 @@
-# Rasterizer
+# `gs.renderers.Rasterizer`
 
 The default renderer: fast, GPU-accelerated rasterization for real-time viewing, control loops, and reinforcement-learning rollouts. It is also the backend the interactive viewer always uses. Enable it explicitly with `gs.Scene(renderer=gs.renderers.Rasterizer())`, though it is already the default when `renderer` is omitted.
 
@@ -14,9 +14,9 @@ The options class takes no parameters. Rasterizer behavior such as shadows, ligh
 
 ```{eval-rst}
 .. autoclass:: genesis.vis.rasterizer.Rasterizer
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/visualization/renderers/raytracer.md
+++ b/source/api_reference/visualization/renderers/raytracer.md
@@ -1,4 +1,4 @@
-# RayTracer
+# `gs.renderers.RayTracer`
 
 A path-tracing renderer backed by LuisaRender, for photorealistic stills with global illumination, reflections, and refractions. Enable it with `gs.Scene(renderer=gs.renderers.RayTracer(...))`. Per-camera ray-tracing settings such as `spp` (samples per pixel), `denoise`, `model` (`"pinhole"` or `"thinlens"`), `aperture`, and `focus_dist` are passed to `scene.add_camera()`, not to the renderer.
 

--- a/source/api_reference/visualization/viewer.md
+++ b/source/api_reference/visualization/viewer.md
@@ -1,4 +1,4 @@
-# Viewer
+# `Viewer`
 
 The interactive window that renders a scene in real time, with mouse and keyboard camera controls. It is optional: pass `show_viewer=True` to `gs.Scene(...)` to open it, and omit it (or pass `show_viewer=False`) to run headless. The viewer always uses the rasterizer backend, independent of the scene's `renderer`. For the walkthrough, mouse and keyboard controls, and the `gs` command-line tools, see {doc}`/user_guide/interaction/visualization`.
 
@@ -23,23 +23,21 @@ for _ in range(1000):
 
 ```{eval-rst}
 .. autoclass:: genesis.vis.viewer.Viewer
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## ViewerOptions
 
 ```{eval-rst}
 .. autoclass:: genesis.options.ViewerOptions
-    :show-inheritance:
 ```
 
 ## VisOptions
 
 ```{eval-rst}
 .. autoclass:: genesis.options.VisOptions
-    :show-inheritance:
 ```
 
 ## See also

--- a/source/api_reference/visualization/visualizer.md
+++ b/source/api_reference/visualization/visualizer.md
@@ -1,4 +1,4 @@
-# Visualizer
+# `Visualizer`
 
 The orchestrator behind `scene.visualizer`, created automatically with every scene. It owns the interactive viewer, the camera sensors, and the renderer backend, and it refreshes them when you call `scene.visualizer.update()`. You rarely construct or call it directly: add cameras with `scene.add_camera(...)`, open the viewer with `show_viewer=True`, and drive both by stepping the scene and calling `update()` each step.
 
@@ -16,9 +16,9 @@ for _ in range(1000):
 
 ```{eval-rst}
 .. autoclass:: genesis.vis.Visualizer
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:
 ```
 
 ## See also

--- a/source/conf.py
+++ b/source/conf.py
@@ -130,8 +130,27 @@ def _add_favicon_links(app, pagename, templatename, context, doctree):
     context["metatags"] = context.get("metatags", "") + links
 
 
+def _clean_pydantic_signatures(app, what, name, obj, options, signature, return_annotation):
+    # Pydantic models keep the Annotated[...] validator metadata in their field
+    # annotations, which autodoc renders as unreadable
+    # `tuple[typing.Annotated[..., FieldInfo(...)]]` blobs in the class signature.
+    # Recompute the signature: sphinx's stringify_signature drops the Annotated
+    # extras, leaving clean, readable type hints (e.g. `tuple[float, ...] | float`).
+    import pydantic
+    from sphinx.util.inspect import signature as sphinx_signature, stringify_signature
+
+    if what != "class" or not isinstance(obj, type) or not issubclass(obj, pydantic.BaseModel):
+        return None
+    try:
+        cleaned = stringify_signature(sphinx_signature(obj))
+    except Exception:
+        return None
+    return cleaned, return_annotation
+
+
 def setup(app):
     app.connect("html-page-context", _add_favicon_links)
+    app.connect("autodoc-process-signature", _clean_pydantic_signatures)
 
 
 ### Autodoc configurations ###


### PR DESCRIPTION
Brings every page under `source/api_reference/` up to `STYLE_GUIDE.md`, removes duplication, fixes factual errors found along the way, and closes coverage gaps. Three commits, one per phase.

## 1. Normalize headings and autodoc directives
- **One heading convention.** Backticked `gs.*` construction path for user-facing config classes (`` `gs.morphs.Box` ``, `` `gs.options.RigidOptions` ``); backticked class name for classes users receive but don't construct (`` `RigidEntity` ``, `` `SAPCoupler` ``); sentence-case prose titles for index/overview pages.
- **Autodoc by class type.** Pydantic classes (options, materials, morphs, surfaces, textures, sensor/recorder options, lights) use a bare `.. autoclass::` — their fields are already documented in the class docstring. Plain classes (entities, `Scene`, engine sensors, vis objects, `Recorder`) get `:members: :undoc-members: :show-inheritance:`. This removes the duplicated fields and leaked `model_config`/`model_post_init` that the member listing produced on Pydantic pages (the material pages carried this noise before).
- Stripped trailing whitespace on 82 `{eval-rst}` fences, unified directive indentation, blank line after each H1.

## 2. Dedup, factual fixes, reorganization
- **Factual fixes** (these were wrong, not just unstyled):
  - `SAPCoupler` is the Semi-Analytic Primal contact solver used in Drake, not "Sweep and Prune".
  - Dropped invalid examples `LegacyCouplerOptions(friction=...)` and `IPCCouplerOptions(d_hat=...)` — the real fields are the coupling-pair booleans and `contact_d_hat`.
  - `constants.md` documented `gs.backend.cpu`; the idiomatic API is top-level `gs.cpu`/`gs.gpu`/…
- **Removed drift-prone tables** from the solver pages (hand-written option/material tables that duplicated and had drifted from the autodoc source — e.g. `max_collision_pairs` listed as 150; source default is 100). Kept the method overview, a minimal example, and solver-unique docs; linked the canonical pages.
- **Collapsed single-child sections** (`material/sf`, `material/sph`, `options/surface/emission`) into leaf pages; retitled the misleading `PBDEntity` index; added intro prose to the family indexes.
- Normalized every "See also" to the colon style.

## 3. Coverage — newly documented public classes
- Recorder options: `NPZFile`, `CSVFile`, `VideoFile`, and the four plotters (replacing stale content that named nonexistent `CSVFileWriter`-style classes).
- Sensor config options: `Contact`, `ContactForce`, `IMU`, `Raycaster`, `DepthCamera`.
- Lights: `DirectionalLight`, `PointLight`, `AmbientLight`.
- Morphs: `gs.morphs.Nowhere`, `gs.morphs.MeshSet`.

## Verification
- Clean `make html`: 16 warnings, all pre-existing `genesis` source-docstring issues, none introduced here; no broken `{doc}`/`{py}` references and no orphaned pages (157/157 reachable from a toctree).
- Every documented `gs.*` path and every symbol referenced in the utilities pages was checked against the installed `genesis` source.
- Rendered spot-checks: Pydantic pages render one clean entry (no `model_config`), plain classes list their methods, the corrected coupler/solver pages render as intended.

## Follow-ups (not in this PR)
- A few detail pages (some `sensor/*`, `utilities/*`) are accurate but still read in an older, more verbose style; a prose polish pass could follow.
- The 16 build warnings are rST issues in `genesis` docstrings (source repo), out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)