### PR TITLE
Reorganize user guide section pages

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -212,6 +212,7 @@ We build with Sphinx + MyST Markdown (`pydata_sphinx_theme`). Use the following,
 **Headings**
 - One `#` H1 per page, matching the page's job. **No emoji in headings.** They break scannability, sorting, and search, and read as decoration. (Existing emoji headings should be removed as pages are touched.)
 - **Content headings use sentence case; navigation titles use Title Case.** Every heading inside a page is sentence case. The exception is navigation: the two top-level section landing titles (`User Guide`, `API Reference`) and the sidebar `:caption:` labels in a `{toctree}` (`Getting Started`, `Robot Control`, …) are Title Case, because they read as proper section names rather than page content.
+- **Don't start a page or section title with an article.** Name the subject directly: `Sensor pipeline`, not "The sensor pipeline"; `Support field`, not "The support field". A leading "The"/"A"/"An" adds nothing to a title, sorts and scans worse, and pushes the real word right. (An article mid-title, or in a content heading where it reads naturally, is fine.)
 - **Spell out "and" in headings and toctree captions — never `&`** (see §4).
 - Don't skip levels (no H2 → H4). `myst_heading_anchors` generates anchors down to H4; keep meaningful headings within that depth.
 
@@ -276,6 +277,7 @@ Before opening a docs PR, confirm:
 - [ ] No space-aligned keyword arguments; Python is `black`-clean.
 - [ ] The page leads with what it's for and a runnable example within one screen.
 - [ ] In-page headings are sentence case with no emoji; section/navigation titles (top-level section pages, toctree captions) are Title Case.
+- [ ] No page or section title begins with an article ("The", "A", "An").
 - [ ] Terminology matches §6; the product is "Genesis World" (not keyword-stuffed).
 - [ ] No jokes, no marketing superlatives, no "let's".
 - [ ] Headings, titles, and captions spell out "and" — no ampersands (`&`).

--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -48,6 +48,18 @@ html[data-theme="dark"] {
   padding: 0.35rem 0;
 }
 
+/* Left sidebar: the top-level entries are now real section landing pages, so
+   drop the "Section Navigation" header and give those entries the regular
+   high-contrast body-text color instead of the muted link color the theme
+   uses for all sidebar links. The active section still gets the primary
+   highlight (theme's `.current > a`), so exclude it here. */
+nav.bd-links p.bd-links__title {
+  display: none;
+}
+nav.bd-links li.toctree-l1:not(.current) > a.reference {
+  color: var(--pst-color-text-base);
+}
+
 .bd-footer .footer-items__start,
 .bd-footer .footer-items__end {
   font-size: 0.75rem;

--- a/source/api_reference/sensor/index.md
+++ b/source/api_reference/sensor/index.md
@@ -1,6 +1,6 @@
 # Sensors
 
-Sensors read information out of a scene without changing its physics. You attach a sensor to a link, step the simulation, and read back a tensor each step. This page catalogs the sensor types and their return shapes; for the attach-and-read model, imperfections, history, and batched reads, see {doc}`the sensors guide </user_guide/sensing/sensors/index>`.
+Sensors read information out of a scene without changing its physics. You attach a sensor to a link, step the simulation, and read back a tensor each step. This page catalogs the sensor types and their return shapes; for the attach-and-read model, imperfections, history, and batched reads, see {doc}`the sensors guide </user_guide/sensing/index>`.
 
 ## Sensor types
 
@@ -90,6 +90,6 @@ other
 
 ## See also
 
-- {doc}`/user_guide/sensing/sensors/index`: the attach-and-read model, imperfections, history, and batched reads.
+- {doc}`/user_guide/sensing/index`: the attach-and-read model, imperfections, history, and batched reads.
 - {doc}`/api_reference/visualization/index`: the rendering and camera system.
 - {doc}`/api_reference/entity/index`: entities and links that sensors attach to.

--- a/source/api_reference/sensor/other.md
+++ b/source/api_reference/sensor/other.md
@@ -6,7 +6,7 @@ Create each one from its `gs.sensors.*` options object with `scene.add_sensor()`
 
 ## SurfaceDistanceProbe
 
-Reports the nearest distance from each probe point to the mesh surfaces of a set of tracked rigid links, clamped to `probe_radius` when nothing is in range. The matching nearest points are available on the `nearest_points` attribute. See {doc}`the proximity guide </user_guide/sensing/sensors/proximity>`.
+Reports the nearest distance from each probe point to the mesh surfaces of a set of tracked rigid links, clamped to `probe_radius` when nothing is in range. The matching nearest points are available on the `nearest_points` attribute. See {doc}`the proximity guide </user_guide/sensing/proximity>`.
 
 ```{eval-rst}
 .. autoclass:: genesis.options.sensors.options.SurfaceDistanceProbe
@@ -22,7 +22,7 @@ Reports the nearest distance from each probe point to the mesh surfaces of a set
 
 ## TemperatureGrid
 
-Overlays a 3D voxel grid on one rigid link and reports the temperature of every cell, in degrees Celsius, evolving each cell from contact conduction, radiation, convection, and optional per-cell heat generation. See {doc}`the temperature grid guide </user_guide/sensing/sensors/temperature_grid>`.
+Overlays a 3D voxel grid on one rigid link and reports the temperature of every cell, in degrees Celsius, evolving each cell from contact conduction, radiation, convection, and optional per-cell heat generation. See {doc}`the temperature grid guide </user_guide/sensing/temperature_grid>`.
 
 Material properties are supplied through a `properties_dict` mapping a global rigid-link index to a `TemperatureProperties` entry.
 

--- a/source/api_reference/sensor/raycaster.md
+++ b/source/api_reference/sensor/raycaster.md
@@ -121,7 +121,7 @@ The Raycaster uses a GPU-accelerated Linear BVH (LBVH) for efficient ray-scene i
 
 ## Depth camera
 
-The `DepthCameraSensor` is a raycaster driven by a `DepthCameraPattern`. It exposes everything the raycaster does, plus `read_image()`, which reshapes the per-ray hit distances into a depth image of shape `([n_envs,] height, width)` (misses carry `no_hit_value`). See {doc}`the raycaster guide </user_guide/sensing/sensors/raycaster>` for usage.
+The `DepthCameraSensor` is a raycaster driven by a `DepthCameraPattern`. It exposes everything the raycaster does, plus `read_image()`, which reshapes the per-ray hit distances into a depth image of shape `([n_envs,] height, width)` (misses carry `no_hit_value`). See {doc}`the raycaster guide </user_guide/sensing/raycaster>` for usage.
 
 ```python
 depth_cam = scene.add_sensor(

--- a/source/api_reference/sensor/tactile.md
+++ b/source/api_reference/sensor/tactile.md
@@ -7,7 +7,7 @@ Two families share this interface but estimate contact differently:
 - **SDF-query probes** (`ContactProbe`, `ContactDepthProbe`, `KinematicTaxel`) query the signed distance from each probe to nearby collision geometry. They need no list of target links.
 - **Point-cloud probes** (`ElastomerTaxel`, `ProximityTaxel`) sample a point cloud from the tracked meshes and measure against those points.
 
-Create a sensor from the matching `gs.sensors.*` options object with `scene.add_sensor()`; the call returns the sensor handle whose `read()` gives the measured value. For the attach-and-read model, probe layout with `probe_local_pos`, and the force models behind each estimate, see {doc}`the contact and tactile sensors guide </user_guide/sensing/sensors/contact_and_tactile>`.
+Create a sensor from the matching `gs.sensors.*` options object with `scene.add_sensor()`; the call returns the sensor handle whose `read()` gives the measured value. For the attach-and-read model, probe layout with `probe_local_pos`, and the force models behind each estimate, see {doc}`the contact and tactile sensors guide </user_guide/sensing/contact_and_tactile>`.
 
 ## ContactProbe
 
@@ -100,5 +100,5 @@ Estimates per-taxel force and torque from a point cloud sampled on the tracked m
 ## See also
 
 - {doc}`index` - Sensor overview
-- {doc}`/user_guide/sensing/sensors/contact_and_tactile` - Usage, probe layout, and force models
+- {doc}`/user_guide/sensing/contact_and_tactile` - Usage, probe layout, and force models
 - {doc}`contact` - Solver-based contact and contact-force sensing

--- a/source/api_reference/visualization/camera.md
+++ b/source/api_reference/visualization/camera.md
@@ -19,7 +19,7 @@ rgb, depth, segmentation, normal = cam.render(
 )
 ```
 
-Each array is shaped `(height, width, ...)`. For image types, video recording, moving and entity-following cameras, and choosing a backend, see {doc}`/user_guide/rendering/rendering`.
+Each array is shaped `(height, width, ...)`. For image types, video recording, moving and entity-following cameras, and choosing a backend, see {doc}`/user_guide/rendering/index`.
 
 :::{note}
 Do not confuse this with the {doc}`camera sensor </api_reference/sensor/camera>`. The camera sensor is added with `scene.add_sensor(gs.sensors.*CameraOptions(...))` and its `read()` returns a `CameraReturnType` carrying a single `rgb` field. The visualization camera here renders RGB together with depth, segmentation, and normals.
@@ -36,6 +36,6 @@ Do not confuse this with the {doc}`camera sensor </api_reference/sensor/camera>`
 
 ## See also
 
-- {doc}`/user_guide/rendering/rendering`: cameras, image types, and video
+- {doc}`/user_guide/rendering/index`: cameras, image types, and video
 - {doc}`renderers/index`: rendering backends
 - {doc}`/api_reference/sensor/index`: other sensor types

--- a/source/api_reference/visualization/index.md
+++ b/source/api_reference/visualization/index.md
@@ -63,5 +63,5 @@ lights
 ## See also
 
 - {doc}`/user_guide/interaction/visualization`: the interactive viewer and command-line tools
-- {doc}`/user_guide/rendering/rendering`: cameras, image types, video, and rendering backends
+- {doc}`/user_guide/rendering/index`: cameras, image types, video, and rendering backends
 - {doc}`/api_reference/sensor/camera`: the camera sensor, read through the sensor interface

--- a/source/api_reference/visualization/lights.md
+++ b/source/api_reference/visualization/lights.md
@@ -26,7 +26,7 @@ scene = gs.Scene(
 )
 ```
 
-For the task-oriented explanation, see {doc}`/user_guide/rendering/rendering`.
+For the task-oriented explanation, see {doc}`/user_guide/rendering/index`.
 
 ## SphereLight
 

--- a/source/api_reference/visualization/renderers/batch_renderer.md
+++ b/source/api_reference/visualization/renderers/batch_renderer.md
@@ -2,7 +2,7 @@
 
 A high-throughput renderer that renders many parallel environments together on the GPU, for large-scale data collection and reinforcement-learning observation generation. Enable it with `gs.Scene(renderer=gs.renderers.BatchRenderer(use_rasterizer=True))`; set `use_rasterizer=False` to path-trace instead. It requires the `gs-madrona` package.
 
-With `n_envs > 1`, camera outputs gain a leading batch dimension, for example `rgb` with shape `(n_envs, height, width, 3)`. For installation and a runnable example, see {doc}`/user_guide/rendering/rendering`.
+With `n_envs > 1`, camera outputs gain a leading batch dimension, for example `rgb` with shape `(n_envs, height, width, 3)`. For installation and a runnable example, see {doc}`/user_guide/rendering/index`.
 
 Unlike the rasterizer, the batch renderer takes its lights at runtime through `scene.add_light(...)` after the scene is created, rather than from `VisOptions`:
 

--- a/source/api_reference/visualization/renderers/index.md
+++ b/source/api_reference/visualization/renderers/index.md
@@ -1,6 +1,6 @@
 # Renderers
 
-A renderer is the backend that camera sensors use to turn a scene into images. Select one per scene by passing an instance to `gs.Scene(renderer=...)`; the choice applies to every camera sensor and does not affect the interactive viewer, which always rasterizes. For the task-oriented walkthrough, see {doc}`/user_guide/rendering/rendering`.
+A renderer is the backend that camera sensors use to turn a scene into images. Select one per scene by passing an instance to `gs.Scene(renderer=...)`; the choice applies to every camera sensor and does not affect the interactive viewer, which always rasterizes. For the task-oriented walkthrough, see {doc}`/user_guide/rendering/index`.
 
 | Renderer | Speed | Quality | Use it for |
 |---|---|---|---|
@@ -25,5 +25,5 @@ batch_renderer
 
 ## See also
 
-- {doc}`/user_guide/rendering/rendering`: adding cameras, image types, video, and backends
+- {doc}`/user_guide/rendering/index`: adding cameras, image types, video, and backends
 - {doc}`/api_reference/visualization/lights`: lighting a rendered scene

--- a/source/api_reference/visualization/renderers/rasterizer.md
+++ b/source/api_reference/visualization/renderers/rasterizer.md
@@ -2,7 +2,7 @@
 
 The default renderer: fast, GPU-accelerated rasterization for real-time viewing, control loops, and reinforcement-learning rollouts. It is also the backend the interactive viewer always uses. Enable it explicitly with `gs.Scene(renderer=gs.renderers.Rasterizer())`, though it is already the default when `renderer` is omitted.
 
-The options class takes no parameters. Rasterizer behavior such as shadows, lights, and per-environment isolation (`env_separate_rigid`) is configured on `gs.options.VisOptions`, not on the renderer. See {doc}`/user_guide/rendering/rendering` for adding cameras and reading back images.
+The options class takes no parameters. Rasterizer behavior such as shadows, lights, and per-environment isolation (`env_separate_rigid`) is configured on `gs.options.VisOptions`, not on the renderer. See {doc}`/user_guide/rendering/index` for adding cameras and reading back images.
 
 ## Options
 

--- a/source/api_reference/visualization/renderers/raytracer.md
+++ b/source/api_reference/visualization/renderers/raytracer.md
@@ -2,7 +2,7 @@
 
 A path-tracing renderer backed by LuisaRender, for photorealistic stills with global illumination, reflections, and refractions. Enable it with `gs.Scene(renderer=gs.renderers.RayTracer(...))`. Per-camera ray-tracing settings such as `spp` (samples per pixel), `denoise`, `model` (`"pinhole"` or `"thinlens"`), `aperture`, and `focus_dist` are passed to `scene.add_camera()`, not to the renderer.
 
-Photorealistic output depends on entity {doc}`surfaces </api_reference/options/surface/index>` (metal, glass, plastic, emission) and on scene {doc}`lighting </api_reference/visualization/lights>`. For setup and a worked example, see {doc}`/user_guide/rendering/rendering`.
+Photorealistic output depends on entity {doc}`surfaces </api_reference/options/surface/index>` (metal, glass, plastic, emission) and on scene {doc}`lighting </api_reference/visualization/lights>`. For setup and a worked example, see {doc}`/user_guide/rendering/index`.
 
 :::{warning}
 This backend is deprecated in favor of {doc}`Nyx </user_guide/rendering/nyx_renderer>` and must be built from source (the LuisaRender extra). Prefer Nyx for new work.

--- a/source/user_guide/assets/index.md
+++ b/source/user_guide/assets/index.md
@@ -1,0 +1,18 @@
+# Loading Assets
+
+Almost everything you put in a scene, a robot, a rigid object, a static prop, comes from an asset file loaded through a **morph**: the object that pairs an entity's geometry with its initial pose and scale, and that you pass as the first argument to `scene.add_entity(...)`. This section covers getting external geometry into Genesis World correctly, from the file formats it accepts to the preparation a mesh needs before it simulates well.
+
+Begin with the general loading workflow, which applies to every format, then read the format- and task-specific pages as you need them: importing a full USD scene, or processing a raw mesh into the separate visual and collision representations the engine expects.
+
+- {doc}`loading_assets` is the foundation: the supported morph types and file formats, the pose and scale options common to all of them, and how Genesis World resolves asset paths.
+- {doc}`usd_import` covers importing [Universal Scene Description](https://openusd.org/) files, including the physics properties Genesis World reads from a USD stage.
+- {doc}`mesh_processing` explains the two jobs a mesh must do, looking right as a visual mesh and behaving well as a collision mesh, and the processing (convex decomposition, simplification) that reconciles them.
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+loading_assets
+usd_import
+mesh_processing
+```

--- a/source/user_guide/assets/index.md
+++ b/source/user_guide/assets/index.md
@@ -1,12 +1,6 @@
 # Loading Assets
 
-Almost everything you put in a scene, a robot, a rigid object, a static prop, comes from an asset file loaded through a **morph**: the object that pairs an entity's geometry with its initial pose and scale, and that you pass as the first argument to `scene.add_entity(...)`. This section covers getting external geometry into Genesis World correctly, from the file formats it accepts to the preparation a mesh needs before it simulates well.
-
-Begin with the general loading workflow, which applies to every format, then read the format- and task-specific pages as you need them: importing a full USD scene, or processing a raw mesh into the separate visual and collision representations the engine expects.
-
-- {doc}`loading_assets` is the foundation: the supported morph types and file formats, the pose and scale options common to all of them, and how Genesis World resolves asset paths.
-- {doc}`usd_import` covers importing [Universal Scene Description](https://openusd.org/) files, including the physics properties Genesis World reads from a USD stage.
-- {doc}`mesh_processing` explains the two jobs a mesh must do, looking right as a visual mesh and behaving well as a collision mesh, and the processing (convex decomposition, simplification) that reconciles them.
+Almost everything you put in a scene comes from an asset file loaded through a **morph**: the object that pairs an entity's geometry with its initial pose and scale, and that you pass as the first argument to `scene.add_entity(...)`. This section covers getting external geometry into Genesis World correctly, from the supported file formats to the mesh preparation that makes a model simulate well. Start with the general loading workflow, which applies to every format.
 
 ```{toctree}
 :hidden:

--- a/source/user_guide/configuration/config_system.md
+++ b/source/user_guide/configuration/config_system.md
@@ -103,5 +103,5 @@ franka = scene.add_entity(
 
 - {doc}`/user_guide/getting_started/hello_genesis`: the minimal scene that uses these options.
 - {doc}`/user_guide/interaction/visualization`: the interactive viewer and command-line tools.
-- {doc}`/user_guide/rendering/rendering`: cameras, image types, video, and rendering backends.
+- {doc}`/user_guide/rendering/index`: cameras, image types, video, and rendering backends.
 - {doc}`Options API reference </api_reference/options/index>`: every option class and its fields.

--- a/source/user_guide/configuration/index.md
+++ b/source/user_guide/configuration/index.md
@@ -1,14 +1,6 @@
 # Concepts and Configuration
 
-The {doc}`Getting Started </user_guide/getting_started/index>` tutorials show what a Genesis World program looks like; this section explains why it looks that way and how to configure every part of it. Its throughline is the two-phase model at the heart of the API: you first *describe* a scene by adding entities and options, then *build* it once and *step* it. Almost every configuration choice is made in the describe phase and frozen at build time, so knowing what belongs where is what keeps a program correct.
-
-Read this section when you want to move past copying a tutorial and reason about the object model, choose backends and precision deliberately, set options in a principled way, or save and restore simulation state. The pages progress from the concepts every program relies on to the specific knobs you turn.
-
-- {doc}`concepts` is the object and computation model: how a scene contains entities and a simulator, how the describe-then-build phases work, and the local-versus-global indexing scheme that lets one entity address its own slice of a solver's data.
-- {doc}`initialization` covers `gs.init()`: selecting the compute backend, fixing numeric precision, and seeding randomness, all decisions made once before any scene exists.
-- {doc}`config_system` explains the typed **options objects** under `gs.options.*` that configure the scene, the solvers, and each entity, and how they compose.
-- {doc}`conventions` is the reference for the coordinate system, rotation representations, physical units, tensor shapes, and data types the whole API shares.
-- {doc}`checkpoints` shows how to snapshot the dynamic state of a scene and restore it, for resetting, branching, or resuming a simulation.
+Where Getting Started shows what a program looks like, this section explains why. Its throughline is the two-phase model at the heart of the API: you first *describe* a scene, then *build* it once and *step* it, and almost every configuration choice is made in the describe phase and frozen at build time. Read it to understand the object model and to set backends, options, conventions, and saved state deliberately.
 
 ```{toctree}
 :hidden:

--- a/source/user_guide/configuration/index.md
+++ b/source/user_guide/configuration/index.md
@@ -1,0 +1,22 @@
+# Concepts and Configuration
+
+The {doc}`Getting Started </user_guide/getting_started/index>` tutorials show what a Genesis World program looks like; this section explains why it looks that way and how to configure every part of it. Its throughline is the two-phase model at the heart of the API: you first *describe* a scene by adding entities and options, then *build* it once and *step* it. Almost every configuration choice is made in the describe phase and frozen at build time, so knowing what belongs where is what keeps a program correct.
+
+Read this section when you want to move past copying a tutorial and reason about the object model, choose backends and precision deliberately, set options in a principled way, or save and restore simulation state. The pages progress from the concepts every program relies on to the specific knobs you turn.
+
+- {doc}`concepts` is the object and computation model: how a scene contains entities and a simulator, how the describe-then-build phases work, and the local-versus-global indexing scheme that lets one entity address its own slice of a solver's data.
+- {doc}`initialization` covers `gs.init()`: selecting the compute backend, fixing numeric precision, and seeding randomness, all decisions made once before any scene exists.
+- {doc}`config_system` explains the typed **options objects** under `gs.options.*` that configure the scene, the solvers, and each entity, and how they compose.
+- {doc}`conventions` is the reference for the coordinate system, rotation representations, physical units, tensor shapes, and data types the whole API shares.
+- {doc}`checkpoints` shows how to snapshot the dynamic state of a scene and restore it, for resetting, branching, or resuming a simulation.
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+concepts
+initialization
+config_system
+conventions
+checkpoints
+```

--- a/source/user_guide/developers/extending_genesis.md
+++ b/source/user_guide/developers/extending_genesis.md
@@ -44,4 +44,4 @@ Because the two callables identify the registration, pass named functions (or ho
 ## See also
 
 - {doc}`/user_guide/configuration/initialization`: what `gs.init()` and `gs.destroy()` do.
-- {doc}`/user_guide/developers/sensors/index`: writing a custom sensor, another extension point.
+- {doc}`/user_guide/sensing/custom_sensors/index`: writing a custom sensor, another extension point.

--- a/source/user_guide/developers/index.md
+++ b/source/user_guide/developers/index.md
@@ -1,12 +1,6 @@
 # Developers
 
-This section is for building on Genesis World rather than only using it: extending the engine with your own resources, following the conventions the codebase holds itself to, and measuring where a simulation spends its time. Read it when you are writing a package on top of Genesis World, contributing upstream, or chasing a performance problem that the task-oriented guides do not address.
-
-The extension points are deliberately narrow and documented; the conventions exist so that contributed code reads like the code around it. If you are adding a new **sensor** type specifically, that guide has moved next to the sensors it complements, see {doc}`Custom sensors </user_guide/sensing/custom_sensors/index>`.
-
-- {doc}`extending_genesis` shows how to tie an external package's setup and teardown to `gs.init()` and `gs.destroy()`, so your extension's lifecycle tracks the engine's.
-- {doc}`naming_and_variables` is the reference for the naming and indexing conventions used across the API and the source: how entities are identified, and how local and global indices relate.
-- {doc}`profiling` covers measuring simulation performance, from coarse frame timing down to per-kernel detail.
+This section is for building on Genesis World rather than only using it: extending the engine with your own resources, following the conventions the codebase holds itself to, and measuring where a simulation spends its time. To add a new **sensor** type, see {doc}`Custom sensors </user_guide/sensing/custom_sensors/index>`.
 
 ```{toctree}
 :hidden:

--- a/source/user_guide/developers/index.md
+++ b/source/user_guide/developers/index.md
@@ -1,0 +1,18 @@
+# Developers
+
+This section is for building on Genesis World rather than only using it: extending the engine with your own resources, following the conventions the codebase holds itself to, and measuring where a simulation spends its time. Read it when you are writing a package on top of Genesis World, contributing upstream, or chasing a performance problem that the task-oriented guides do not address.
+
+The extension points are deliberately narrow and documented; the conventions exist so that contributed code reads like the code around it. If you are adding a new **sensor** type specifically, that guide has moved next to the sensors it complements, see {doc}`Custom sensors </user_guide/sensing/custom_sensors/index>`.
+
+- {doc}`extending_genesis` shows how to tie an external package's setup and teardown to `gs.init()` and `gs.destroy()`, so your extension's lifecycle tracks the engine's.
+- {doc}`naming_and_variables` is the reference for the naming and indexing conventions used across the API and the source: how entities are identified, and how local and global indices relate.
+- {doc}`profiling` covers measuring simulation performance, from coarse frame timing down to per-kernel detail.
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+extending_genesis
+naming_and_variables
+profiling
+```

--- a/source/user_guide/getting_started/hello_genesis.md
+++ b/source/user_guide/getting_started/hello_genesis.md
@@ -121,4 +121,4 @@ for i in range(1000):
 
 ## Next steps
 
-Continue with {doc}`Control your robot <control_your_robot>` to actuate the Franka you just loaded, then {doc}`Visualization </user_guide/interaction/visualization>` to work with the viewer and {doc}`Rendering </user_guide/rendering/rendering>` to capture images.
+Continue with {doc}`Control your robot <control_your_robot>` to actuate the Franka you just loaded, then {doc}`Visualization </user_guide/interaction/visualization>` to work with the viewer and {doc}`Rendering </user_guide/rendering/index>` to capture images.

--- a/source/user_guide/getting_started/index.md
+++ b/source/user_guide/getting_started/index.md
@@ -1,13 +1,6 @@
 # Getting Started
 
-These tutorials teach Genesis World by building working programs, one idea at a time. Together they cover the full arc of a simulation: initialize the engine, describe a scene, build it, step it, control what is in it, and scale it to thousands of parallel copies on the GPU. Work through them in order if you are new; each one assumes the one before it.
-
-Every Genesis World program follows the same shape, and these pages introduce it piece by piece before the rest of the guide goes deep on any single part. By the end you will have loaded and actuated a robot, run batched environments, and know where to find the larger example scripts that combine these ideas into complete tasks.
-
-- {doc}`hello_genesis` is the smallest complete program: load a Franka arm above a ground plane and let it fall. Under fifteen lines, it already contains every step common to any Genesis World simulation.
-- {doc}`control_your_robot` actuates that arm with the built-in controllers, introducing the position and force control modes and the joint and DOF indexing you use to command them.
-- {doc}`parallel_simulation` runs many copies of a scene at once on the GPU. This batched execution is what makes Genesis World fast enough for reinforcement learning and large-scale data generation.
-- {doc}`more_examples` is the map to the repository's runnable example tree, which shows these ideas combined into realistic tasks you can run and adapt.
+These tutorials teach Genesis World by building working programs, one idea at a time: initialize the engine, describe and build a scene, step it, control what is in it, and scale to thousands of parallel copies on the GPU. Work through them in order if you are new; each assumes the one before.
 
 ```{toctree}
 :hidden:

--- a/source/user_guide/getting_started/index.md
+++ b/source/user_guide/getting_started/index.md
@@ -1,0 +1,20 @@
+# Getting Started
+
+These tutorials teach Genesis World by building working programs, one idea at a time. Together they cover the full arc of a simulation: initialize the engine, describe a scene, build it, step it, control what is in it, and scale it to thousands of parallel copies on the GPU. Work through them in order if you are new; each one assumes the one before it.
+
+Every Genesis World program follows the same shape, and these pages introduce it piece by piece before the rest of the guide goes deep on any single part. By the end you will have loaded and actuated a robot, run batched environments, and know where to find the larger example scripts that combine these ideas into complete tasks.
+
+- {doc}`hello_genesis` is the smallest complete program: load a Franka arm above a ground plane and let it fall. Under fifteen lines, it already contains every step common to any Genesis World simulation.
+- {doc}`control_your_robot` actuates that arm with the built-in controllers, introducing the position and force control modes and the joint and DOF indexing you use to command them.
+- {doc}`parallel_simulation` runs many copies of a scene at once on the GPU. This batched execution is what makes Genesis World fast enough for reinforcement learning and large-scale data generation.
+- {doc}`more_examples` is the map to the repository's runnable example tree, which shows these ideas combined into realistic tasks you can run and adapt.
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+hello_genesis
+control_your_robot
+parallel_simulation
+more_examples
+```

--- a/source/user_guide/index.md
+++ b/source/user_guide/index.md
@@ -1,133 +1,20 @@
 # User Guide
 
-This guide takes you from installation through the core concepts and tutorials for Genesis World. If you are new, start with {doc}`overview/what_is_genesis` and the {doc}`getting_started/hello_genesis` tutorial, then branch into the topic that matches what you are building.
+This guide takes you from installation through the core concepts and tutorials for Genesis World. If you are new, start with the {doc}`Overview <overview/index>` and the {doc}`Hello, Genesis World <getting_started/hello_genesis>` tutorial, then branch into the section that matches what you are building. Each section below opens with a landing page that frames the topic and points to its pages; expand a section in the sidebar to jump straight to one.
 
 ```{toctree}
-:caption: Overview
-:maxdepth: 1
-
-overview/what_is_genesis
-overview/installation
-```
-
-
-```{toctree}
-:caption: Getting Started
-:maxdepth: 1
-
-getting_started/hello_genesis
-getting_started/control_your_robot
-getting_started/parallel_simulation
-getting_started/more_examples
-```
-
-
-```{toctree}
-:caption: Concepts and Configuration
-:maxdepth: 1
-
-configuration/concepts
-configuration/initialization
-configuration/config_system
-configuration/conventions
-configuration/checkpoints
-```
-
-
-```{toctree}
-:caption: Debugging and Interaction
-:maxdepth: 1
-
-interaction/visualization
-interaction/interactive_debugging
-interaction/viewer_plugin
-```
-
-
-```{toctree}
-:caption: Robot Control
-:maxdepth: 1
-
-robot_control/inverse_kinematics_motion_planning
-robot_control/advanced_ik
-robot_control/constraints
-robot_control/path_planning
-```
-
-
-```{toctree}
-:caption: Physical Entities
-:maxdepth: 1
-
-physics/rigid_bodies
-physics/beyond_rigid_bodies
-physics/soft_robots
-physics/hybrid_entity
-physics/drone_entity
-physics/terrain
-physics/emitters
-physics/force_fields
-```
-
-
-```{toctree}
-:caption: Sensing and Perception
 :maxdepth: 2
 
-sensing/sensors/index
-sensing/recorders
-```
-
-
-```{toctree}
-:caption: Rendering
-:maxdepth: 1
-
-rendering/rendering
-rendering/surfaces_textures
-rendering/nyx_renderer
-```
-
-
-```{toctree}
-:caption: Loading Assets
-:maxdepth: 1
-
-assets/loading_assets
-assets/usd_import
-assets/mesh_processing
-```
-
-
-```{toctree}
-:caption: Policy Training
-:maxdepth: 2
-
-policy_training/best_practices/index
-policy_training/examples/index
-policy_training/multi_gpu
-```
-
-
-```{toctree}
-:caption: Theory and Modelling
-:maxdepth: 2
-
-theory/rigid_collision/index
-theory/solvers_and_coupling
-theory/couplers/index
-theory/nonrigid_models
-theory/support_field
-theory/hibernation
-```
-
-
-```{toctree}
-:caption: Developers
-:maxdepth: 2
-
-developers/extending_genesis
-developers/sensors/index
-developers/naming_and_variables
-developers/profiling
+overview/index
+getting_started/index
+configuration/index
+interaction/index
+robot_control/index
+physics/index
+sensing/index
+rendering/index
+assets/index
+policy_training/index
+theory/index
+developers/index
 ```

--- a/source/user_guide/interaction/index.md
+++ b/source/user_guide/interaction/index.md
@@ -1,12 +1,6 @@
 # Debugging and Interaction
 
-Simulations are easier to build when you can see and poke at them. This section covers the tools for watching a Genesis World scene as it runs and for inspecting what it is doing while you develop: the interactive viewer window, the debug drawing and inspection facilities, and the plugin hooks that let you drive the viewer with your own code.
-
-These are development-time tools, meant for a machine with a display. To capture images off-screen or produce photorealistic frames, whether headless or not, see {doc}`Rendering </user_guide/rendering/index>` instead; the two share the scene's `visualizer` but serve different purposes.
-
-- {doc}`visualization` is the starting point: the interactive **viewer** window and the `gs` command-line tools that open a scene without writing a script.
-- {doc}`interactive_debugging` covers the three complementary ways to understand a running scene, rich interactive inspection from a Python shell, debug drawing overlaid on the view, and the built-in state readouts.
-- {doc}`viewer_plugin` shows how to extend the viewer itself: register keybindings, mouse interactions, and plugins that hook into the running simulation.
+Simulations are easier to build when you can see and poke at them. This section covers the development-time tools for watching a Genesis World scene and inspecting what it does: the interactive viewer, debug drawing and inspection, and the viewer's plugin hooks. To capture images off-screen or render photorealistically, whether headless or not, see {doc}`Rendering </user_guide/rendering/index>` instead.
 
 ```{toctree}
 :hidden:

--- a/source/user_guide/interaction/index.md
+++ b/source/user_guide/interaction/index.md
@@ -1,0 +1,18 @@
+# Debugging and Interaction
+
+Simulations are easier to build when you can see and poke at them. This section covers the tools for watching a Genesis World scene as it runs and for inspecting what it is doing while you develop: the interactive viewer window, the debug drawing and inspection facilities, and the plugin hooks that let you drive the viewer with your own code.
+
+These are development-time tools, meant for a machine with a display. To capture images off-screen or produce photorealistic frames, whether headless or not, see {doc}`Rendering </user_guide/rendering/index>` instead; the two share the scene's `visualizer` but serve different purposes.
+
+- {doc}`visualization` is the starting point: the interactive **viewer** window and the `gs` command-line tools that open a scene without writing a script.
+- {doc}`interactive_debugging` covers the three complementary ways to understand a running scene, rich interactive inspection from a Python shell, debug drawing overlaid on the view, and the built-in state readouts.
+- {doc}`viewer_plugin` shows how to extend the viewer itself: register keybindings, mouse interactions, and plugins that hook into the running simulation.
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+visualization
+interactive_debugging
+viewer_plugin
+```

--- a/source/user_guide/interaction/interactive_debugging.md
+++ b/source/user_guide/interaction/interactive_debugging.md
@@ -175,5 +175,5 @@ The full example is [`imgui_joint_control.py`](https://github.com/Genesis-Embodi
 ## See also
 
 - {doc}`/user_guide/interaction/viewer_plugin` for keybindings and writing your own viewer plugins.
-- {doc}`/user_guide/rendering/rendering` for cameras, rendering, and recording.
+- {doc}`/user_guide/rendering/index` for cameras, rendering, and recording.
 - {doc}`/user_guide/getting_started/hello_genesis` for the core simulation loop.

--- a/source/user_guide/interaction/viewer_plugin.md
+++ b/source/user_guide/interaction/viewer_plugin.md
@@ -184,4 +184,4 @@ Debug geometry is drawn from `on_draw()`, which runs every frame. Call `self.sce
 ## See also
 
 - {doc}`Interactive GUI and debugging </user_guide/interaction/interactive_debugging>`: the ImGui overlay, joint sliders, and simulation controls.
-- {doc}`Rendering </user_guide/rendering/rendering>`: cameras, rendering, and recording video.
+- {doc}`Rendering </user_guide/rendering/index>`: cameras, rendering, and recording video.

--- a/source/user_guide/interaction/visualization.md
+++ b/source/user_guide/interaction/visualization.md
@@ -1,8 +1,8 @@
 # Visualization
 
-This page covers watching a Genesis World scene as it runs: the interactive **viewer** window, and the `gs` command-line tools that open it without writing a script. Reach for these while developing on a machine with a display. To render images off-screen (color, depth, segmentation, video) or produce photorealistic frames, see {doc}`Rendering </user_guide/rendering/rendering>`.
+This page covers watching a Genesis World scene as it runs: the interactive **viewer** window, and the `gs` command-line tools that open it without writing a script. Reach for these while developing on a machine with a display. To render images off-screen (color, depth, segmentation, video) or produce photorealistic frames, see {doc}`Rendering </user_guide/rendering/index>`.
 
-Every scene owns a `visualizer` (`scene.visualizer`) that drives both the viewer and camera sensors. The viewer runs in its own thread and follows the simulation in real time; camera sensors render frames on demand and work headless (see {doc}`Rendering </user_guide/rendering/rendering>`).
+Every scene owns a `visualizer` (`scene.visualizer`) that drives both the viewer and camera sensors. The viewer runs in its own thread and follows the simulation in real time; camera sensors render frames on demand and work headless (see {doc}`Rendering </user_guide/rendering/index>`).
 
 ## The viewer
 
@@ -30,7 +30,7 @@ scene = gs.Scene(
 
 `camera_pos` and `camera_lookat` are in meters, in the right-handed, Z-up world frame. `camera_fov` is the vertical field of view in degrees. If `res` is `None`, Genesis World opens a 4:3 window sized to half your display height.
 
-The viewer always renders with the rasterizer. To select the backend used by camera sensors (rasterizer, ray tracer, or batch renderer), see {doc}`Rendering backends </user_guide/rendering/rendering>`.
+The viewer always renders with the rasterizer. To select the backend used by camera sensors (rasterizer, ray tracer, or batch renderer), see {doc}`Rendering backends </user_guide/rendering/index>`.
 
 :::{note}
 To cap the viewer frame rate, set `refresh_rate` on `ViewerOptions`. The older `max_FPS` argument is deprecated and now maps to `refresh_rate`.
@@ -71,6 +71,6 @@ gs animate 'frames/*.png' --fps 60
 
 ## Next steps
 
-- {doc}`Rendering </user_guide/rendering/rendering>`: cameras, image types, video, lighting, and rendering backends.
+- {doc}`Rendering </user_guide/rendering/index>`: cameras, image types, video, lighting, and rendering backends.
 - {doc}`Interactive GUI and debugging </user_guide/interaction/interactive_debugging>`: inspecting objects, drawing debug geometry, and the in-viewer control panel.
 - {doc}`Viewer interaction and plugins </user_guide/interaction/viewer_plugin>`: extending the viewer with keybindings and plugins.

--- a/source/user_guide/overview/index.md
+++ b/source/user_guide/overview/index.md
@@ -1,0 +1,16 @@
+# Overview
+
+Genesis World is a simulation platform for physical AI development. It combines a unified multi-physics engine, a photorealistic renderer ([Nyx](https://github.com/Genesis-Embodied-AI/genesis-nyx)), and a cross-platform compiler ([Quadrants](https://github.com/Genesis-Embodied-AI/quadrants)) behind a single Pythonic API, and it scales from a laptop CPU to datacenter GPUs without a change to your code.
+
+This section is the orientation for everything that follows. Read it first to understand what the platform is and where it came from, then install it so the {doc}`Getting Started </user_guide/getting_started/index>` tutorials have something to run against. It carries no simulation code of its own; the hands-on material begins in the next section.
+
+- {doc}`what_is_genesis` explains the design in one place: the multi-physics engine, the rendering and compilation stack, and the project's history from an academic release to its current development. Read it for the mental model and the vocabulary the rest of the guide assumes.
+- {doc}`installation` covers installing on Linux, macOS, and Windows, on CPU and on CUDA and non-CUDA GPUs, along with the optional renderers and the choices (backend, precision) you make once at install time.
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+what_is_genesis
+installation
+```

--- a/source/user_guide/overview/index.md
+++ b/source/user_guide/overview/index.md
@@ -1,11 +1,8 @@
 # Overview
 
-Genesis World is a simulation platform for physical AI development. It combines a unified multi-physics engine, a photorealistic renderer ([Nyx](https://github.com/Genesis-Embodied-AI/genesis-nyx)), and a cross-platform compiler ([Quadrants](https://github.com/Genesis-Embodied-AI/quadrants)) behind a single Pythonic API, and it scales from a laptop CPU to datacenter GPUs without a change to your code.
+Genesis World is a simulation platform for physical AI development: a unified multi-physics engine, a photorealistic renderer ([Nyx](https://github.com/Genesis-Embodied-AI/genesis-nyx)), and a cross-platform compiler ([Quadrants](https://github.com/Genesis-Embodied-AI/quadrants)) behind a single Pythonic API, scaling from a laptop CPU to datacenter GPUs without a change to your code.
 
-This section is the orientation for everything that follows. Read it first to understand what the platform is and where it came from, then install it so the {doc}`Getting Started </user_guide/getting_started/index>` tutorials have something to run against. It carries no simulation code of its own; the hands-on material begins in the next section.
-
-- {doc}`what_is_genesis` explains the design in one place: the multi-physics engine, the rendering and compilation stack, and the project's history from an academic release to its current development. Read it for the mental model and the vocabulary the rest of the guide assumes.
-- {doc}`installation` covers installing on Linux, macOS, and Windows, on CPU and on CUDA and non-CUDA GPUs, along with the optional renderers and the choices (backend, precision) you make once at install time.
+This section orients you and gets the platform installed before the {doc}`Getting Started </user_guide/getting_started/index>` tutorials begin.
 
 ```{toctree}
 :hidden:

--- a/source/user_guide/overview/installation.md
+++ b/source/user_guide/overview/installation.md
@@ -48,7 +48,7 @@ source ~/.bashrc
 
 ### Ray-tracing renderer
 
-For photorealistic stills, Genesis World includes a ray-tracing renderer built on [LuisaCompute](https://github.com/LuisaGroup/LuisaCompute). It is built from source; see {doc}`/user_guide/rendering/rendering` for setup. For new work, prefer the {doc}`Nyx renderer </user_guide/rendering/nyx_renderer>`.
+For photorealistic stills, Genesis World includes a ray-tracing renderer built on [LuisaCompute](https://github.com/LuisaGroup/LuisaCompute). It is built from source; see {doc}`/user_guide/rendering/index` for setup. For new work, prefer the {doc}`Nyx renderer </user_guide/rendering/nyx_renderer>`.
 
 ### USD assets
 

--- a/source/user_guide/physics/index.md
+++ b/source/user_guide/physics/index.md
@@ -1,17 +1,6 @@
 # Physical Entities
 
-A Genesis World scene is not limited to rigid robots. The same `Scene` can hold water, sand, cloth, soft muscle-driven bodies, quadrotors, and terrain, each simulated by the solver suited to it, and each added through the same `scene.add_entity(...)` call you already know. This section is the tour of those entity families: what each one is, when to reach for it, and the material and morph options that define it.
-
-Rigid bodies are the default and the foundation, so start there; the remaining pages cover the non-rigid and specialized families that build on the same API. How these different solvers interact when entities of different types touch, the coupling that makes a multi-physics scene consistent, is a separate topic covered under {doc}`Theory and Modelling </user_guide/theory/index>`.
-
-- {doc}`rigid_bodies` is the default entity type and the overview for the rest: a solid that does not deform, covering most of robotics, arms, grippers, mobile bases, and the props they interact with.
-- {doc}`beyond_rigid_bodies` introduces the deformable and fluid families, cloth, liquids, granular media, and elastic solids, and the solvers behind them.
-- {doc}`soft_robots` covers deformable bodies driven by embedded **muscle fibers** rather than joint motors.
-- {doc}`hybrid_entity` couples a rigid skeleton to a soft skin so the two simulate as one body.
-- {doc}`drone_entity` is the quadrotor entity, actuated by four propeller speeds instead of joint commands.
-- {doc}`terrain` builds a static rigid ground from a height field, the standard ground for locomotion work.
-- {doc}`emitters` stream particles into a particle solver as the simulation runs, for continuous sources like a hose or a nozzle.
-- {doc}`force_fields` apply a spatially varying acceleration to an entity's particles every substep, for wind, vortices, and other body forces.
+A Genesis World scene is not limited to rigid robots: the same `Scene` can hold water, sand, cloth, soft muscle-driven bodies, quadrotors, and terrain, each simulated by the solver suited to it and each added through the same `scene.add_entity(...)` call. Rigid bodies are the default and the foundation, so start there; the remaining pages cover the non-rigid and specialized families. How different solvers interact where their entities touch is covered separately under {doc}`Theory and Modelling </user_guide/theory/index>`.
 
 ```{toctree}
 :hidden:

--- a/source/user_guide/physics/index.md
+++ b/source/user_guide/physics/index.md
@@ -1,0 +1,28 @@
+# Physical Entities
+
+A Genesis World scene is not limited to rigid robots. The same `Scene` can hold water, sand, cloth, soft muscle-driven bodies, quadrotors, and terrain, each simulated by the solver suited to it, and each added through the same `scene.add_entity(...)` call you already know. This section is the tour of those entity families: what each one is, when to reach for it, and the material and morph options that define it.
+
+Rigid bodies are the default and the foundation, so start there; the remaining pages cover the non-rigid and specialized families that build on the same API. How these different solvers interact when entities of different types touch, the coupling that makes a multi-physics scene consistent, is a separate topic covered under {doc}`Theory and Modelling </user_guide/theory/index>`.
+
+- {doc}`rigid_bodies` is the default entity type and the overview for the rest: a solid that does not deform, covering most of robotics, arms, grippers, mobile bases, and the props they interact with.
+- {doc}`beyond_rigid_bodies` introduces the deformable and fluid families, cloth, liquids, granular media, and elastic solids, and the solvers behind them.
+- {doc}`soft_robots` covers deformable bodies driven by embedded **muscle fibers** rather than joint motors.
+- {doc}`hybrid_entity` couples a rigid skeleton to a soft skin so the two simulate as one body.
+- {doc}`drone_entity` is the quadrotor entity, actuated by four propeller speeds instead of joint commands.
+- {doc}`terrain` builds a static rigid ground from a height field, the standard ground for locomotion work.
+- {doc}`emitters` stream particles into a particle solver as the simulation runs, for continuous sources like a hose or a nozzle.
+- {doc}`force_fields` apply a spatially varying acceleration to an entity's particles every substep, for wind, vortices, and other body forces.
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+rigid_bodies
+beyond_rigid_bodies
+soft_robots
+hybrid_entity
+drone_entity
+terrain
+emitters
+force_fields
+```

--- a/source/user_guide/policy_training/examples/manipulation.md
+++ b/source/user_guide/policy_training/examples/manipulation.md
@@ -69,7 +69,7 @@ else:
     cam_kwargs = {}
 ```
 
-The cameras are added with `scene.add_sensor(...)`; see {doc}`Camera sensors </user_guide/sensing/sensors/camera_sensors>` for the sensor API and {doc}`Parallel simulation </user_guide/getting_started/parallel_simulation>` for how batched environments run.
+The cameras are added with `scene.add_sensor(...)`; see {doc}`Camera sensors </user_guide/sensing/camera_sensors>` for the sensor API and {doc}`Parallel simulation </user_guide/getting_started/parallel_simulation>` for how batched environments run.
 
 ### Actions and control
 
@@ -198,5 +198,5 @@ The evaluation script reuses the configuration pickled during training (`logs/<e
 ## See also
 
 - {doc}`Training locomotion policies with RL <locomotion>` and {doc}`training drone hovering policies with RL <hover_env>` for single-stage PPO examples with the same environment shape.
-- {doc}`Camera sensors </user_guide/sensing/sensors/camera_sensors>` for the rendering API behind the stereo observations.
+- {doc}`Camera sensors </user_guide/sensing/camera_sensors>` for the rendering API behind the stereo observations.
 - {doc}`Control your robot </user_guide/getting_started/control_your_robot>` for the inverse-kinematics and position-control primitives the environment uses.

--- a/source/user_guide/policy_training/index.md
+++ b/source/user_guide/policy_training/index.md
@@ -1,12 +1,6 @@
 # Policy Training
 
-Genesis World is built for reinforcement learning at scale: thousands of environments running in parallel on a single GPU, and multiple GPUs beyond that. At that scale the bottleneck is rarely the learning algorithm; it is how efficiently each environment steps and how well the whole pipeline keeps the GPU busy. This section covers both the principles that make large-scale training work and the complete, runnable examples that put them into practice.
-
-Read the best-practices material first to understand what governs throughput and sim-to-real transfer, then study the worked examples as templates for your own tasks, and turn to multi-GPU when one device is no longer enough. It assumes you are comfortable with {doc}`parallel simulation </user_guide/getting_started/parallel_simulation>`, which introduces the batched execution these environments rely on.
-
-- {doc}`best_practices/index` collects what decides whether training succeeds at scale: writing an environment whose `step()` does not stall the GPU, and randomizing the simulation so a policy transfers to hardware.
-- {doc}`examples/index` walks through the end-to-end RL pipelines that ship with Genesis World, drone hover, quadruped locomotion, and two-stage manipulation, each a gym-style environment plus a training script you can run as-is.
-- {doc}`multi_gpu` covers scaling training across several GPUs, the second axis of parallelism beyond the batched environments within one device.
+Genesis World is built for reinforcement learning at scale: thousands of environments in parallel on one GPU, and multiple GPUs beyond that. At that scale the bottleneck is rarely the learning algorithm but how efficiently each environment steps and how well the pipeline keeps the GPU busy. This section covers the best practices that make large-scale training work, the complete RL examples that ship with Genesis World, and scaling across multiple GPUs. It assumes you are comfortable with {doc}`parallel simulation </user_guide/getting_started/parallel_simulation>`.
 
 ```{toctree}
 :hidden:

--- a/source/user_guide/policy_training/index.md
+++ b/source/user_guide/policy_training/index.md
@@ -1,0 +1,18 @@
+# Policy Training
+
+Genesis World is built for reinforcement learning at scale: thousands of environments running in parallel on a single GPU, and multiple GPUs beyond that. At that scale the bottleneck is rarely the learning algorithm; it is how efficiently each environment steps and how well the whole pipeline keeps the GPU busy. This section covers both the principles that make large-scale training work and the complete, runnable examples that put them into practice.
+
+Read the best-practices material first to understand what governs throughput and sim-to-real transfer, then study the worked examples as templates for your own tasks, and turn to multi-GPU when one device is no longer enough. It assumes you are comfortable with {doc}`parallel simulation </user_guide/getting_started/parallel_simulation>`, which introduces the batched execution these environments rely on.
+
+- {doc}`best_practices/index` collects what decides whether training succeeds at scale: writing an environment whose `step()` does not stall the GPU, and randomizing the simulation so a policy transfers to hardware.
+- {doc}`examples/index` walks through the end-to-end RL pipelines that ship with Genesis World, drone hover, quadruped locomotion, and two-stage manipulation, each a gym-style environment plus a training script you can run as-is.
+- {doc}`multi_gpu` covers scaling training across several GPUs, the second axis of parallelism beyond the batched environments within one device.
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+
+best_practices/index
+examples/index
+multi_gpu
+```

--- a/source/user_guide/rendering/index.md
+++ b/source/user_guide/rendering/index.md
@@ -186,3 +186,11 @@ python examples/rigid/single_franka_batch_render.py
 - {doc}`Visualization </user_guide/interaction/visualization>`: the interactive viewer and the `gs` command-line tools.
 - {doc}`Surfaces and textures <surfaces_textures>`: how entities look when rendered.
 - {doc}`Nyx renderer <nyx_renderer>`: photorealistic path tracing in depth.
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+surfaces_textures
+nyx_renderer
+```

--- a/source/user_guide/rendering/index.md
+++ b/source/user_guide/rendering/index.md
@@ -67,7 +67,7 @@ If you omit `save_to_filename`, Genesis World generates a name from the calling 
 <source src="../../_static/videos/cam_record.mp4" type="video/mp4">
 </video>
 
-For recording sensor and simulation data (not just video) on a schedule, see {doc}`Recorders </user_guide/sensing/recorders>`.
+For recording sensor and simulation data (not just video) on a schedule, see {doc}`Recording data </user_guide/sensing/recorders>`.
 
 ## Lighting
 

--- a/source/user_guide/rendering/nyx_renderer.md
+++ b/source/user_guide/rendering/nyx_renderer.md
@@ -10,7 +10,7 @@ That distinction is the whole idea. The other rendering backends are selected on
 
 ## When to use Nyx
 
-Genesis World offers several ways to turn a scene into pixels (see {doc}`Rendering <rendering>` for the full list). Choose by what you need:
+Genesis World offers several ways to turn a scene into pixels (see {doc}`Rendering <index>` for the full list). Choose by what you need:
 
 | You want… | Use |
 |---|---|

--- a/source/user_guide/rendering/surfaces_textures.md
+++ b/source/user_guide/rendering/surfaces_textures.md
@@ -112,7 +112,7 @@ scene = gs.Scene(
 ```
 
 :::{note}
-Surfaces render on both the interactive viewer's rasterizer and the ray tracer, but reflections, refraction, transmission, and emission-based lighting are only fully resolved by the ray tracer. See {doc}`Rendering <rendering>` for how to choose and configure a renderer.
+Surfaces render on both the interactive viewer's rasterizer and the ray tracer, but reflections, refraction, transmission, and emission-based lighting are only fully resolved by the ray tracer. See {doc}`Rendering <index>` for how to choose and configure a renderer.
 :::
 
 ## Visualizing something other than the visual mesh
@@ -164,6 +164,6 @@ scene.add_entity(
 
 ## Next steps
 
-- {doc}`Rendering <rendering>`: cameras and choosing a renderer.
+- {doc}`Rendering <index>`: cameras and choosing a renderer.
 - {doc}`Nyx renderer <nyx_renderer>`: the ray tracer and its options in depth.
 - {doc}`USD import </user_guide/assets/usd_import>`: loading assets that carry their own surfaces.

--- a/source/user_guide/robot_control/index.md
+++ b/source/user_guide/robot_control/index.md
@@ -1,13 +1,6 @@
 # Robot Control
 
-Getting a robot to do something useful means turning a goal in task space, "put the gripper here", into motion in joint space that respects the robot's kinematics and its surroundings. This section covers the tools Genesis World provides for that: inverse kinematics to find configurations that reach a pose, motion and path planning to connect configurations without collisions, and constraints to tie links together into mechanisms.
-
-It builds directly on {doc}`Control your robot </user_guide/getting_started/control_your_robot>`, which introduced the position and force control modes; here the question is not how to command a joint but what to command it to. Start with the combined IK-and-planning tutorial for the end-to-end workflow, then reach for the individual pages when a specific need arises.
-
-- {doc}`inverse_kinematics_motion_planning` is the complete pick-and-place walkthrough: solve IK for a target end-effector pose, plan a collision-free path to it, then close the gripper and lift. It also covers the pose conventions IK expects.
-- {doc}`advanced_ik` extends the solver in the two directions that matter for real manipulation and for training: multi-target and multi-link IK, and solving across parallel environments at once.
-- {doc}`constraints` covers rigid-body constraints that keep a geometric relationship between two links, coincident points, a fixed relative pose, or coupled joints.
-- {doc}`path_planning` details `plan_path`, the kinematic planner that finds a collision-free trajectory through joint space from a start to a goal configuration.
+Getting a robot to do something useful means turning a goal in task space, "put the gripper here", into motion in joint space that respects the robot's kinematics and its surroundings. This section covers the tools for that: inverse kinematics, motion and path planning, and constraints. It builds on {doc}`Control your robot </user_guide/getting_started/control_your_robot>`; start with the combined IK-and-planning tutorial for the end-to-end workflow.
 
 ```{toctree}
 :hidden:

--- a/source/user_guide/robot_control/index.md
+++ b/source/user_guide/robot_control/index.md
@@ -1,0 +1,20 @@
+# Robot Control
+
+Getting a robot to do something useful means turning a goal in task space, "put the gripper here", into motion in joint space that respects the robot's kinematics and its surroundings. This section covers the tools Genesis World provides for that: inverse kinematics to find configurations that reach a pose, motion and path planning to connect configurations without collisions, and constraints to tie links together into mechanisms.
+
+It builds directly on {doc}`Control your robot </user_guide/getting_started/control_your_robot>`, which introduced the position and force control modes; here the question is not how to command a joint but what to command it to. Start with the combined IK-and-planning tutorial for the end-to-end workflow, then reach for the individual pages when a specific need arises.
+
+- {doc}`inverse_kinematics_motion_planning` is the complete pick-and-place walkthrough: solve IK for a target end-effector pose, plan a collision-free path to it, then close the gripper and lift. It also covers the pose conventions IK expects.
+- {doc}`advanced_ik` extends the solver in the two directions that matter for real manipulation and for training: multi-target and multi-link IK, and solving across parallel environments at once.
+- {doc}`constraints` covers rigid-body constraints that keep a geometric relationship between two links, coincident points, a fixed relative pose, or coupled joints.
+- {doc}`path_planning` details `plan_path`, the kinematic planner that finds a collision-free trajectory through joint space from a start to a goal configuration.
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+inverse_kinematics_motion_planning
+advanced_ik
+constraints
+path_planning
+```

--- a/source/user_guide/sensing/camera_sensors.md
+++ b/source/user_guide/sensing/camera_sensors.md
@@ -5,7 +5,7 @@ A camera sensor renders the scene to an RGB image off-screen and returns it thro
 A camera sensor is distinct from two things it is easy to confuse it with:
 
 - The **viewer** (`show_viewer=True`) is the interactive window a human watches. It renders live and returns nothing to your code. See {doc}`/user_guide/interaction/visualization`.
-- The **visualization camera** (`scene.add_camera().render(...)`) renders color, depth, segmentation, and surface-normal images on demand. Use it when you want the four image channels. It is covered in {doc}`/user_guide/rendering/rendering`.
+- The **visualization camera** (`scene.add_camera().render(...)`) renders color, depth, segmentation, and surface-normal images on demand. Use it when you want the four image channels. It is covered in {doc}`/user_guide/rendering/index`.
 
 A camera sensor, by contrast, is a first-class {doc}`sensor <index>`: it renders lazily on `read()`, participates in the batched `scene.read_sensors()` path, and can be attached to a moving link like any other sensor. It returns **RGB only**.
 
@@ -142,7 +142,7 @@ All `BatchRendererCameraOptions` cameras in a scene must share the same resoluti
 ## Notes and gotchas
 
 :::{note}
-**Camera sensors return RGB only.** `read()` gives you the color image and nothing else. For depth, segmentation masks, or surface normals, use the visualization camera's `render()` method (see {doc}`/user_guide/rendering/rendering`) or, for depth specifically, the {doc}`depth-camera raycaster sensor <raycaster>`.
+**Camera sensors return RGB only.** `read()` gives you the color image and nothing else. For depth, segmentation masks, or surface normals, use the visualization camera's `render()` method (see {doc}`/user_guide/rendering/index`) or, for depth specifically, the {doc}`depth-camera raycaster sensor <raycaster>`.
 :::
 
 :::{warning}
@@ -151,6 +151,6 @@ Camera sensors do not support `history_length`. They render lazily on `read()` a
 
 ## See also
 
-- {doc}`/user_guide/rendering/rendering`: the visualization camera's four image channels, video recording, and rendering backends.
+- {doc}`/user_guide/rendering/index`: the visualization camera's four image channels, video recording, and rendering backends.
 - {doc}`Sensors <index>`: the sensor pipeline, batched reads, and other sensor families.
 - {doc}`Raycaster sensors <raycaster>`: depth camera and lidar with configurable ray patterns.

--- a/source/user_guide/sensing/contact_and_tactile.md
+++ b/source/user_guide/sensing/contact_and_tactile.md
@@ -61,7 +61,7 @@ Configuration:
 - `Contact` accepts `threshold` (a positive force magnitude registers as contact above this value; default `0.0`) and `filter_link_idx`, a list of **global** link indices whose contacts with the sensor link are ignored.
 - `ContactForce` clamps each axis to `[min_force, max_force]`; readings below `min_force` are zeroed and readings above `max_force` are saturated. Both default to no clamping.
 
-```{figure} ../../../_static/images/contact_force_sensor.png
+```{figure} ../../_static/images/contact_force_sensor.png
 :alt: A Go2 quadruped standing on a ground plane, with a magenta arrow drawn at each foot showing the contact force reported by that foot's ContactForce sensor
 ```
 
@@ -156,7 +156,7 @@ data.torque  # shape ([n_envs,] n_probes, 3), N·m, link frame
 `read()` returns a `KinematicTaxelReturnType` named tuple, so `data.force` and `data.torque` unpack by name.
 
 <video preload="auto" controls="True" width="100%" aria-label="A live vector-field plot of KinematicTaxel forces across a probe grid as an object presses into the sensor, with arrows growing where penetration is deepest">
-<source src="../../../_static/videos/kin_probe_data.mp4" type="video/mp4">
+<source src="../../_static/videos/kin_probe_data.mp4" type="video/mp4">
 Your browser does not support the video tag.
 </video>
 
@@ -184,7 +184,7 @@ displacement = tactile.read()  # shape ([n_envs,] n_probes, 3), m
 `dilate_scale` and `shear_scale` scale the indentation and shear response; `lambda_d` and `lambda_s` control how far each effect spreads across neighboring markers. When `probe_local_pos` is a regular planar grid with a single shared normal, the dilation term is computed with an FFT to keep large arrays fast.
 
 <video preload="auto" controls="True" width="100%" aria-label="A Franka gripper with taxel grids on both fingertips grasping objects; marker displacement vectors on each fingertip deflect as the fingers make contact">
-<source src="../../../_static/videos/tactile_fingertips.mp4" type="video/mp4">
+<source src="../../_static/videos/tactile_fingertips.mp4" type="video/mp4">
 Your browser does not support the video tag.
 </video>
 
@@ -217,7 +217,7 @@ Like `KinematicTaxel`, it returns a named tuple (`ProximityTaxelReturnType`) wit
 The sandbox demo presses different objects into a taxel pad across four parallel environments:
 
 <video preload="auto" controls="True" width="100%" aria-label="The tactile sandbox demo pressing objects into an elastomer taxel pad across four parallel environments, with marker displacement fields responding to each object's shape">
-<source src="../../../_static/videos/elastomer_sandbox.mp4" type="video/mp4">
+<source src="../../_static/videos/elastomer_sandbox.mp4" type="video/mp4">
 Your browser does not support the video tag.
 </video>
 
@@ -225,4 +225,4 @@ Your browser does not support the video tag.
 
 - {doc}`Sensors overview <index>`: sampling rate, `read_ground_truth()`, batched `scene.read_sensors()`, noise, delay, and `history_length`.
 - {doc}`Proximity <proximity>`: nearest-distance probes to tracked mesh surfaces, without a force estimate.
-- {doc}`Extending Genesis World → Sensors </user_guide/developers/sensors/index>`: the sensor pipeline and how to add your own sensor type.
+- {doc}`Extending Genesis World → Sensors </user_guide/sensing/custom_sensors/index>`: the sensor pipeline and how to add your own sensor type.

--- a/source/user_guide/sensing/custom_sensors/custom_sensors.md
+++ b/source/user_guide/sensing/custom_sensors/custom_sensors.md
@@ -1,6 +1,6 @@
 # Writing a custom sensor
 
-This page is for advanced users adding a new sensor type. It is the author's counterpart to the {doc}`sensor pipeline <sensor_pipeline>`, which describes how sensors execute at runtime; here the focus is the interface you implement, the shape and dtype contracts each override must honor, and how the framework pairs your sensor with its options automatically. If you only want to *use* the built-in sensors, start with {doc}`/user_guide/sensing/sensors/index` instead.
+This page is for advanced users adding a new sensor type. It is the author's counterpart to the {doc}`sensor pipeline <sensor_pipeline>`, which describes how sensors execute at runtime; here the focus is the interface you implement, the shape and dtype contracts each override must honor, and how the framework pairs your sensor with its options automatically. If you only want to *use* the built-in sensors, start with {doc}`/user_guide/sensing/index` instead.
 
 The base classes live in `genesis/engine/sensors/base_sensor.py`. In almost every case you derive from `SimpleSensor` and override only the hooks you need. Deriving directly from `Sensor` is reserved for sensors that bypass the standard pipeline entirely, and the built-in cameras do exactly that through `BaseCameraSensor`.
 
@@ -315,4 +315,4 @@ To pick the right hooks, mirror the closest built-in sensor. Every one implement
 ## See also
 
 - {doc}`sensor_pipeline`: how the pipeline executes at runtime, and the intermediate-versus-return separation in full.
-- {doc}`/user_guide/sensing/sensors/index`: using the built-in sensors.
+- {doc}`/user_guide/sensing/index`: using the built-in sensors.

--- a/source/user_guide/sensing/custom_sensors/index.md
+++ b/source/user_guide/sensing/custom_sensors/index.md
@@ -1,6 +1,6 @@
 # Custom sensors
 
-The {doc}`sensor overview </user_guide/sensing/sensors/index>` covers the user-facing side: attach a sensor with `scene.add_sensor()`, step the simulation, and read a tensor. This section is for the other side of that boundary. Read it when the built-in sensors are not enough and you need to add your own type, or when you want to understand what happens between `scene.step()` and the value `sensor.read()` hands back.
+The {doc}`sensor overview </user_guide/sensing/index>` covers the user-facing side: attach a sensor with `scene.add_sensor()`, step the simulation, and read a tensor. This section is for the other side of that boundary. Read it when the built-in sensors are not enough and you need to add your own type, or when you want to understand what happens between `scene.step()` and the value `sensor.read()` hands back.
 
 The two pages differ in audience. The overview treats a sensor as a device you configure and query; here a sensor is a small pipeline you implement. The distinction matters because the pipeline is where imperfections, delay, history, and idempotent reads come from: behavior you rely on as a user but must reproduce correctly as an author.
 

--- a/source/user_guide/sensing/custom_sensors/sensor_pipeline.md
+++ b/source/user_guide/sensing/custom_sensors/sensor_pipeline.md
@@ -1,4 +1,4 @@
-# The sensor pipeline
+# Sensor pipeline
 
 This page explains what happens between `scene.step()` and the value a sensor's `read()` hands back: how the sensor manager updates every sensor once per step, how sensors of different types share expensive computation, and how buffering makes `read()` a constant-time memory lookup rather than a fresh acquisition. It is the runtime companion to {doc}`custom_sensors`, which covers the hooks you override to add a sensor. For the user-facing side (attach a sensor, step, read a tensor) start with the {doc}`sensor overview </user_guide/sensing/index>`.
 

--- a/source/user_guide/sensing/custom_sensors/sensor_pipeline.md
+++ b/source/user_guide/sensing/custom_sensors/sensor_pipeline.md
@@ -1,6 +1,6 @@
 # The sensor pipeline
 
-This page explains what happens between `scene.step()` and the value a sensor's `read()` hands back: how the sensor manager updates every sensor once per step, how sensors of different types share expensive computation, and how buffering makes `read()` a constant-time memory lookup rather than a fresh acquisition. It is the runtime companion to {doc}`custom_sensors`, which covers the hooks you override to add a sensor. For the user-facing side (attach a sensor, step, read a tensor) start with the {doc}`sensor overview </user_guide/sensing/sensors/index>`.
+This page explains what happens between `scene.step()` and the value a sensor's `read()` hands back: how the sensor manager updates every sensor once per step, how sensors of different types share expensive computation, and how buffering makes `read()` a constant-time memory lookup rather than a fresh acquisition. It is the runtime companion to {doc}`custom_sensors`, which covers the hooks you override to add a sensor. For the user-facing side (attach a sensor, step, read a tensor) start with the {doc}`sensor overview </user_guide/sensing/index>`.
 
 ## The mental model: read is a lookup, not an acquisition
 
@@ -200,4 +200,4 @@ The standard sensors (contact, contact force, IMU, joint torque, ranging, proxim
 ## See also
 
 - {doc}`custom_sensors`: which hooks to override to add your own sensor type, and their shape and dtype contracts.
-- {doc}`sensor overview </user_guide/sensing/sensors/index>`: the user-facing attach-and-read workflow and the catalog of built-in sensors.
+- {doc}`sensor overview </user_guide/sensing/index>`: the user-facing attach-and-read workflow and the catalog of built-in sensors.

--- a/source/user_guide/sensing/imu.md
+++ b/source/user_guide/sensing/imu.md
@@ -113,7 +113,7 @@ print(imu.read())
 Both accept an optional `envs_idx` to select a subset of environments, and both are idempotent within a step: repeated calls in one control-loop timestep return the same value.
 
 <video preload="auto" controls="True" width="100%">
-<source src="../../../_static/videos/imu.mp4" type="video/mp4">
+<source src="../../_static/videos/imu.mp4" type="video/mp4">
 Your browser does not support the video tag; the clip shows the IMU arrows tracking a Franka end effector as it traces a circle.
 </video>
 

--- a/source/user_guide/sensing/index.md
+++ b/source/user_guide/sensing/index.md
@@ -73,10 +73,12 @@ Genesis World also ships `gs.sensors.JointTorque`, which reports actuator output
 
 Runnable examples for every sensor live under `examples/sensors/`.
 
-## See also
+## Beyond reading a single sensor
 
-- {doc}`Recorders </user_guide/sensing/recorders>`: save sensor data alongside the simulation.
-- {doc}`Extending Genesis World: sensors </user_guide/developers/sensors/index>`: the sensor pipeline and how to add your own sensor type.
+Two more pages in this section build on the attach-and-read model:
+
+- {doc}`Recorders <recorders>` stream sensor output to disk (or any sink) as the simulation runs, so a training or logging pipeline records data without hand-written per-step plumbing.
+- {doc}`Custom sensors <custom_sensors/index>` is the author's side of the boundary: the per-step pipeline every sensor runs through, and the hooks you override to add a sensor type that is not built in.
 
 ```{toctree}
 :hidden:
@@ -88,4 +90,6 @@ raycaster
 camera_sensors
 proximity
 temperature_grid
+recorders
+custom_sensors/index
 ```

--- a/source/user_guide/sensing/index.md
+++ b/source/user_guide/sensing/index.md
@@ -75,10 +75,7 @@ Runnable examples for every sensor live under `examples/sensors/`.
 
 ## Beyond reading a single sensor
 
-Two more pages in this section build on the attach-and-read model:
-
-- {doc}`Recorders <recorders>` stream sensor output to disk (or any sink) as the simulation runs, so a training or logging pipeline records data without hand-written per-step plumbing.
-- {doc}`Custom sensors <custom_sensors/index>` is the author's side of the boundary: the per-step pipeline every sensor runs through, and the hooks you override to add a sensor type that is not built in.
+{doc}`Recording data <recorders>` covers streaming sensor output to disk as the simulation runs, and {doc}`Custom sensors <custom_sensors/index>` covers the per-step pipeline every sensor runs through and how to add a sensor type that is not built in.
 
 ```{toctree}
 :hidden:

--- a/source/user_guide/sensing/proximity.md
+++ b/source/user_guide/sensing/proximity.md
@@ -63,7 +63,7 @@ Both leading dimensions follow the batched-optional convention: the `[n_envs,]` 
 - **Debug drawing.** With `draw_debug=True` and an active visualizer, the sensor draws a sphere at each probe and a line to its nearest surface point, sized by `debug_sphere_radius` (default 0.008 m).
 
 <video preload="auto" controls="True" width="100%" aria-label="Shadow Hand with proximity probes on its palm and fingertips; lines connect each probe to the nearest point on a tracked duck mesh and box as the hand moves">
-<source src="../../../_static/videos/proximity.mp4" type="video/mp4">
+<source src="../../_static/videos/proximity.mp4" type="video/mp4">
 Your browser does not support the video tag.
 </video>
 

--- a/source/user_guide/sensing/raycaster.md
+++ b/source/user_guide/sensing/raycaster.md
@@ -146,7 +146,7 @@ depth = depth_cam.read_image()  # shape ([n_envs,] 72, 96), meters
 Running `python examples/sensors/lidar_teleop.py --pattern depth` teleoperates a depth camera on the Go2 (`--pattern` also accepts `spherical` and `grid`):
 
 <video preload="auto" controls="True" width="100%" alt="Depth image from a camera sensor mounted on a Go2 robot walking among obstacles">
-<source src="../../../_static/videos/depth_camera.mp4" type="video/mp4">
+<source src="../../_static/videos/depth_camera.mp4" type="video/mp4">
 </video>
 
 ## Common options

--- a/source/user_guide/sensing/raycaster.md
+++ b/source/user_guide/sensing/raycaster.md
@@ -184,5 +184,5 @@ result.distances.shape  # (4, 128, 64)
 
 - {doc}`Sensors overview <index>`: the sensor pipeline, noise, delay, and batched reads.
 - {doc}`Camera sensors <camera_sensors>`: rendered RGB, depth, and segmentation through a camera.
-- {doc}`Recorders </user_guide/sensing/recorders>`: save depth images and point clouds alongside the simulation.
+- {doc}`Recording data </user_guide/sensing/recorders>`: save depth images and point clouds alongside the simulation.
 - {doc}`Conventions </user_guide/configuration/conventions>`: the Z-up frame and unit conventions the returned points follow.

--- a/source/user_guide/sensing/recorders.md
+++ b/source/user_guide/sensing/recorders.md
@@ -36,7 +36,7 @@ Set up all recording **before** `scene.build()`. `start_recording` asserts the s
 
 ## Recording sensor data
 
-For a {doc}`sensor <sensors/index>`, `sensor.start_recording` is the shortest path: it uses the sensor's own `read()` as the data function, so you only pass the recorder options.
+For a {doc}`sensor <index>`, `sensor.start_recording` is the shortest path: it uses the sensor's own `read()` as the data function, so you only pass the recorder options.
 
 ```python
 imu = scene.add_sensor(gs.sensors.IMU(entity_idx=franka.idx))
@@ -130,5 +130,5 @@ scene.stop_recording()  # flushes files, closes plot windows
 ## See also
 
 - {doc}`Recording API reference </api_reference/recording/index>`: `RecorderManager`, `Recorder`, and every recorder options class.
-- {doc}`Sensors <sensors/index>`: the contact, tactile, proximity, IMU, and temperature sensors you can record from.
-- {doc}`Camera sensors <sensors/camera_sensors>`: RGB, depth, segmentation, and normal outputs, which pair with `VideoFile` and `MPLImagePlot`.
+- {doc}`Sensors <index>`: the contact, tactile, proximity, IMU, and temperature sensors you can record from.
+- {doc}`Camera sensors <camera_sensors>`: RGB, depth, segmentation, and normal outputs, which pair with `VideoFile` and `MPLImagePlot`.

--- a/source/user_guide/sensing/recorders.md
+++ b/source/user_guide/sensing/recorders.md
@@ -1,4 +1,4 @@
-# Recorders
+# Recording data
 
 A **recorder** samples data from your simulation on a schedule and processes it for you (writing it to a file or drawing it in a live plot) without you threading logging code through your step loop. You describe *what* to record and *how*, then step the scene as usual.
 

--- a/source/user_guide/sensing/temperature_grid.md
+++ b/source/user_guide/sensing/temperature_grid.md
@@ -96,4 +96,4 @@ A hot pusher and dropped objects heat a sensorized platform, whose temperature g
 ## See also
 
 - {doc}`Sensors <index>`: the sensor pipeline, batched reads, and history.
-- {doc}`Recorders <recorders>`: saving sensor data alongside the simulation.
+- {doc}`Recording data <recorders>`: saving sensor data alongside the simulation.

--- a/source/user_guide/sensing/temperature_grid.md
+++ b/source/user_guide/sensing/temperature_grid.md
@@ -89,11 +89,11 @@ Each field has a fixed unit:
 :::
 
 <video preload="auto" controls="True" width="100%">
-<source src="../../../_static/videos/temperaturegrid.mp4" type="video/mp4">
+<source src="../../_static/videos/temperaturegrid.mp4" type="video/mp4">
 A hot pusher and dropped objects heat a sensorized platform, whose temperature grid shifts from blue to red at the contact regions.
 </video>
 
 ## See also
 
 - {doc}`Sensors <index>`: the sensor pipeline, batched reads, and history.
-- {doc}`Recorders <../recorders>`: saving sensor data alongside the simulation.
+- {doc}`Recorders <recorders>`: saving sensor data alongside the simulation.

--- a/source/user_guide/theory/index.md
+++ b/source/user_guide/theory/index.md
@@ -1,0 +1,24 @@
+# Theory and Modelling
+
+This section explains how the engine works underneath the API. Where the rest of the guide is task-oriented, "how do I add a sensor, control a robot, load a mesh", these pages are reference material for the physics and the algorithms: what happens inside a `scene.step()`, how contacts are found and resolved, how different solvers share one scene, and the material models that govern deformation. Read them when a result surprises you, when you are tuning a hard contact or coupling problem, or when you simply want to understand the machinery.
+
+The unifying fact is that a single `Scene` can run several physics solvers at once, rigid, FEM, MPM, SPH, PBD, and still behave as one consistent world. Most of this section is about how that is made to work: the collision and constraint pipeline for rigid bodies, the couplers that reconcile solvers where their entities meet, the constitutive models behind non-rigid materials, and the shared primitives (the support field) and optimizations (hibernation) underneath.
+
+- {doc}`rigid_collision/index` details the rigid pipeline that runs every step: detecting which bodies touch, building contact manifolds, and solving the constraint forces that keep them from interpenetrating.
+- {doc}`solvers_and_coupling` is the overview of multi-physics: which solvers exist, what each simulates, and how a scene runs them together.
+- {doc}`couplers/index` covers the components that resolve interaction between solvers, including the SAP and IPC contact models.
+- {doc}`nonrigid_models` explains the constitutive models, the stress-strain relationships, behind deformable and fluid materials.
+- {doc}`support_field` describes the support-function abstraction the convex collision algorithms query instead of touching full geometry.
+- {doc}`hibernation` explains how the solver puts settled rigid bodies to sleep to skip work, and what wakes them.
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+
+rigid_collision/index
+solvers_and_coupling
+couplers/index
+nonrigid_models
+support_field
+hibernation
+```

--- a/source/user_guide/theory/index.md
+++ b/source/user_guide/theory/index.md
@@ -1,15 +1,6 @@
 # Theory and Modelling
 
-This section explains how the engine works underneath the API. Where the rest of the guide is task-oriented, "how do I add a sensor, control a robot, load a mesh", these pages are reference material for the physics and the algorithms: what happens inside a `scene.step()`, how contacts are found and resolved, how different solvers share one scene, and the material models that govern deformation. Read them when a result surprises you, when you are tuning a hard contact or coupling problem, or when you simply want to understand the machinery.
-
-The unifying fact is that a single `Scene` can run several physics solvers at once, rigid, FEM, MPM, SPH, PBD, and still behave as one consistent world. Most of this section is about how that is made to work: the collision and constraint pipeline for rigid bodies, the couplers that reconcile solvers where their entities meet, the constitutive models behind non-rigid materials, and the shared primitives (the support field) and optimizations (hibernation) underneath.
-
-- {doc}`rigid_collision/index` details the rigid pipeline that runs every step: detecting which bodies touch, building contact manifolds, and solving the constraint forces that keep them from interpenetrating.
-- {doc}`solvers_and_coupling` is the overview of multi-physics: which solvers exist, what each simulates, and how a scene runs them together.
-- {doc}`couplers/index` covers the components that resolve interaction between solvers, including the SAP and IPC contact models.
-- {doc}`nonrigid_models` explains the constitutive models, the stress-strain relationships, behind deformable and fluid materials.
-- {doc}`support_field` describes the support-function abstraction the convex collision algorithms query instead of touching full geometry.
-- {doc}`hibernation` explains how the solver puts settled rigid bodies to sleep to skip work, and what wakes them.
+This section explains how the engine works underneath the API. Where the rest of the guide is task-oriented, these pages are reference material for the physics and algorithms: what happens inside a `scene.step()`, how contacts are found and resolved, how one scene runs several solvers (rigid, FEM, MPM, SPH, PBD) at once and keeps them consistent, and the material models behind deformation. Read them when a result surprises you, when you are tuning a hard contact or coupling problem, or when you simply want to understand the machinery.
 
 ```{toctree}
 :hidden:

--- a/source/user_guide/theory/rigid_collision/collision_contacts_forces.md
+++ b/source/user_guide/theory/rigid_collision/collision_contacts_forces.md
@@ -82,10 +82,10 @@ This is the aggregate the constraint solver accumulated, so it reflects the reso
 
 ## When to use a contact sensor instead
 
-`get_contacts()` and `get_links_net_contact_force()` pull the whole contact set on demand, which is convenient for scripting and debugging. For a per-link signal you sample every step in a control or training loop (with history, noise, and delay handled for you), attach a contact sensor instead. `ContactForce` reports the net force on a link in its own frame, and the tactile probes estimate dense per-taxel forces. See {doc}`/user_guide/sensing/sensors/contact_and_tactile`.
+`get_contacts()` and `get_links_net_contact_force()` pull the whole contact set on demand, which is convenient for scripting and debugging. For a per-link signal you sample every step in a control or training loop (with history, noise, and delay handled for you), attach a contact sensor instead. `ContactForce` reports the net force on a link in its own frame, and the tactile probes estimate dense per-taxel forces. See {doc}`/user_guide/sensing/contact_and_tactile`.
 
 ## See also
 
 - {doc}`rigid_constraint_model`: how contacts, joint limits, and equality constraints are solved for the resulting motion.
 - {doc}`/user_guide/theory/support_field`: the acceleration structure behind MPR and GJK support queries.
-- {doc}`/user_guide/sensing/sensors/contact_and_tactile`: contact and tactile sensors for per-step readings.
+- {doc}`/user_guide/sensing/contact_and_tactile`: contact and tactile sensors for per-step readings.

--- a/source/user_guide/theory/support_field.md
+++ b/source/user_guide/theory/support_field.md
@@ -1,4 +1,4 @@
-# The support field
+# Support field
 
 Genesis World detects collisions between convex shapes with algorithms that never touch a shape's full geometry directly. Instead, they ask one question repeatedly: *given a direction, which point of the shape lies farthest that way?* The answer is called a **support point**, the function that returns it is a **support function**, and the **support field** is the acceleration structure that answers this question in constant time for arbitrary convex meshes.
 


### PR DESCRIPTION
## Description

Restructures the user guide so that **every section is itself a page** (collapsible in the sidebar), instead of a caption-only nav group. `user_guide/index.md` now has a single toctree of section landing pages, and each section gets an `index.md` with a conceptual intro and a tour of its child pages.

Also acts on two specific pieces of awkwardness:

- **`Sensing and Perception` -> `Sensors`.** The redundant `sensing/sensors/` nesting is flattened up into `sensing/`, so the section landing page *is* the sensor overview (no more `Sensors > Sensors`). The developer-facing **Custom sensors** guide (pipeline + authoring) moves out of `Developers/` and into the Sensors section as a nested, collapsible subsection.
- **Rendering.** The duplicate `rendering/rendering.md` page (a `Rendering` page directly under the `Rendering` section) is merged into `rendering/index.md`.

New/relocated Sensors subtree:

```
Sensors  (sensing/index.md)
|- IMU / Contact and tactile / Raycaster / Camera sensors / Proximity / Temperature grid
|- Recorders
`- Custom sensors        (collapsible)
   |- The sensor pipeline
   `- Writing a custom sensor
```

Twelve section landing pages total: 10 newly written, plus Rendering (merged) and Sensors (absorbed the existing overview).

## Motivation and Context

Section titles were previously plain toctree captions, not navigable pages, which left no place for section-level framing and produced oddities like a `Rendering` page sitting immediately under the `Rendering` caption. Making each section a real landing page gives every topic an intro and a consistent, collapsible structure.

## How Has This Been Tested?

`make html` (via `sphinx-build`) completes with no new warnings. Verified that all 12 section landing pages render, the sidebar shows each section as a clickable entry with its children nested/collapsible, and there are no orphaned pages or broken cross-references. All affected `{doc}` refs across the user guide and API reference were updated, along with the relative image/link depths shifted by the file moves.

## Screenshot

_Sidebar now shows each section as its own collapsible landing page; see the `Sensors` and `Rendering` sections in particular._

## Checklist

- [x] I read the documentation style guide and followed it.
- [x] The docs build locally (`make html`) without new warnings.
