### PR TITLE
Minor fixes to match current source code.

### DIFF
--- a/source/user_guide/assets/mesh_processing.md
+++ b/source/user_guide/assets/mesh_processing.md
@@ -36,7 +36,7 @@ The processing described below applies when the morph becomes a `RigidEntity`. D
 
 When a mesh becomes a rigid entity, Genesis prepares its collision geometry in three stages:
 
-- **Watertighten:** close gaps and remove non-manifold artifacts so the mesh bounds a well-defined volume. Controlled by `watertighten` (an integer 0–8, default 7).
+- **Watertighten:** close gaps and remove non-manifold artifacts so the mesh bounds a well-defined volume. Controlled by `watertighten` (an integer 0–8, default 5).
 - **Decimate:** reduce the triangle count toward a target so narrow-phase collision stays cheap.
 - **Convexify:** replace the mesh with one or more convex hulls, since the collision solver is fastest and most robust on convex shapes.
 

--- a/source/user_guide/sensing/proximity.md
+++ b/source/user_guide/sensing/proximity.md
@@ -59,8 +59,8 @@ Both leading dimensions follow the batched-optional convention: the `[n_envs,]` 
 ## Behavior and units
 
 - **Units.** Distances and probe positions are in meters. The scene uses a right-handed, Z-up frame, and `nearest_points` are in world coordinates.
-- **Clamping at `probe_radius`.** `probe_radius` is the maximum sensing range. When no tracked surface lies within it, the reported distance is clamped to `probe_radius` and the nearest point is the probe's own world position. `probe_radius` accepts a scalar shared by every probe, or a per-probe array matching the probe count; it defaults to 10.0 m.
-- **Debug drawing.** With `draw_debug=True` and an active visualizer, the sensor draws a sphere at each probe and a line to its nearest surface point, sized by `debug_sphere_radius` (default 0.008 m).
+- **Clamping at `probe_radius`.** `probe_radius` is the maximum sensing range. When no tracked surface lies within it, the reported distance is clamped to `probe_radius` and the nearest point is the probe's own world position. `probe_radius` accepts a scalar shared by every probe, or a per-probe array matching the probe count; it defaults to 0.5 m.
+- **Debug drawing.** With `draw_debug=True` and an active visualizer, the sensor draws a small opaque marker sphere at each probe (`debug_probe_center_radius`, default 0.0008 m), a translucent outer sphere sized to `probe_radius` (`debug_probe_sphere_opacity`, default 0.3; set to `0.0` to hide it), and a line to the nearest surface point.
 
 <video preload="auto" controls="True" width="100%" aria-label="Shadow Hand with proximity probes on its palm and fingertips; lines connect each probe to the nearest point on a tracked duck mesh and box as the hand moves">
 <source src="../../_static/videos/proximity.mp4" type="video/mp4">

--- a/source/user_guide/sensing/tactile.md
+++ b/source/user_guide/sensing/tactile.md
@@ -49,14 +49,14 @@ depth = depth_probe.read()  # shape ([n_envs,] n_probes), m
 
 ## Kinematic taxels
 
-`KinematicTaxel` adds a spring-damper force model on top of the depth query. For each taxel it estimates a force from penetration along the probe normal and a torque from the twist, using the probe's motion relative to the object it touches:
+`KinematicTaxel` adds a spring-damper force model on top of the depth query. For each taxel it estimates a force from penetration along the contact surface normal and a torque from the twist, using the probe's motion relative to the object it touches:
 
 ```
 s = penetration ** normal_exponent
-F = -normal_stiffness * s * n  -  normal_damping * s * v_n  -  shear_scalar * v_t
+F = normal_stiffness * s * n  +  normal_damping * s * v_n  -  shear_scalar * v_t
 ```
 
-where `n` is the probe normal, `v_n` / `v_t` are the normal and tangential relative velocities. Use `normal_exponent=1.5` for Hertzian (spherical) contact; the default `1.0` is a linear spring.
+where `n` is the contact surface normal at the probe: the SDF gradient in `"sdf"` mode, or the nearest-triangle face normal in `"raycast"` mode (see `contact_depth_query` above). `v_n` / `v_t` are the normal and tangential relative velocities. Unlike the point-cloud taxels below, `KinematicTaxel` derives `n` from the queried geometry itself rather than from a user-supplied `probe_local_normal`. Use `normal_exponent=1.5` for Hertzian (spherical) contact; the default `1.0` is a linear spring.
 
 ```python
 taxel = scene.add_sensor(
@@ -103,7 +103,7 @@ tactile = scene.add_sensor(
 displacement = tactile.read()  # shape ([n_envs,] n_probes, 3), m
 ```
 
-`dilate_scale` and `shear_scale` scale the indentation and shear response; `lambda_d` and `lambda_s` control how far each effect spreads across neighboring markers. When `probe_local_pos` is a regular planar grid with a single shared normal, the dilation term is computed with an FFT to keep large arrays fast. The shear anchor is gated by the same `contact_threshold` / `release_threshold` Schmitt trigger (a tracked point begins anchoring shear at `contact_threshold` penetration and releases once it separates back to `release_threshold`).
+`dilate_scale` and `shear_scale` scale the indentation and shear response; `lambda_d` and `lambda_s` control how far each effect spreads across neighboring markers. The out-of-plane (normal) bulge scales as `depth ** normal_exponent` (default `2.0`, the HydroShear quadratic response); tangential dilation and shear stay linear in depth regardless of `normal_exponent`. When `probe_local_pos` is a regular planar grid with a single shared normal, the dilation term is computed with an FFT to keep large arrays fast. The shear anchor is gated by the same `contact_threshold` / `release_threshold` Schmitt trigger (a tracked point begins anchoring shear at `contact_threshold` penetration and releases once it separates back to `release_threshold`).
 
 <video preload="auto" controls="True" width="100%" aria-label="A Franka gripper with taxel grids on both fingertips grasping objects; marker displacement vectors on each fingertip deflect as the fingers make contact">
 <source src="../../_static/videos/tactile_fingertips.mp4" type="video/mp4">
@@ -148,7 +148,6 @@ On top of the generic per-sensor imperfections (`noise`, `bias`, `resolution`, `
 | Option(s) | Models | Applies to |
 |---|---|---|
 | `hysteresis_strength`, `hysteresis_tau` | Viscoelastic (single-Maxwell) hysteresis: a step input overshoots by `hysteresis_strength` and relaxes with time constant `hysteresis_tau` seconds; cyclic input traces a loading-unloading loop (equilibrium gain 1). | All probes and taxels |
-| `probe_radius_noise` | Additive uniform noise (meters) on the effective sensing radius used by the measured branch. | All probes and taxels |
 | `probe_gain`, `probe_gain_resample_range` | Per-taxel multiplicative gain on the measured contact depth (scalar or per-taxel array); with a range, resampled uniformly on each `scene.reset()`. | All probes and taxels |
 | `dead_taxel_probability`, `dead_taxel_value_range` | Per-taxel Bernoulli chance of going dead on each `scene.reset()`; a dead taxel's output is replaced by a constant drawn from `dead_taxel_value_range`. | All probes and taxels |
 | `crosstalk_strength`, `crosstalk_sigma` | Gaussian spatial crosstalk: each taxel's force/torque bleeds onto its grid neighbors (`crosstalk_strength=1` is a pure Gaussian blur of width `crosstalk_sigma`). | Grid taxels: `KinematicTaxel`, `ProximityTaxel` |
@@ -168,7 +167,6 @@ taxel = scene.add_sensor(
         # measured-branch imperfections:
         hysteresis_strength=0.5,
         hysteresis_tau=0.1,
-        probe_radius_noise=0.001,
         probe_gain=1.5,
         crosstalk_kernel=misc.gaussian_crosstalk_kernel(3, 3, sigma=1.0),
     )


### PR DESCRIPTION
Automated weekly documentation sync.

Reviews genesis-world source commits `a1363a778a5a7aa642b8840b3aae0b0a28ecc9fc..241b64d984fbbceb53ef6dfc0603a7d2333698dc` for doc-impacting changes.

## Summary of changes

Both edits look correct and consistent with the style guide (colons in definition-style list items, no new em dashes). Also note the minimal example earlier in that same file already uses `probe_radius=0.5,  # max sensing range, meters` — so that example was already aligned with the new default, just the prose default statement was stale.

## Summary

I reviewed the source diff (`a1363a778..241b64d9`, 6 commits) and made targeted updates to reflect the tactile-sensor refactor (675a1e7a, "Refactor and speed up tactile sensors") and a mesh-processing default change. All other changes (nonconvex collision robustness, contact-island solver speedup, thin-shell tunneling fix, the `go2_backflip.py` bugfix) are internal/automatic with no new or changed public API, and the go2_backflip fix was already reflected correctly in `locomotion.md`.

Edits made:

- **`source/user_guide/sensing/tactile.md`**
  - Fixed the `KinematicTaxel` force/torque formula: signs were flipped (now `+normal_stiffness`/`+normal_damping` instead of `-`), and `n` is now documented as the contact surface normal (SDF gradient or raycast face normal) rather than a user-supplied `probe_local_normal` — that parameter was removed from `KinematicTaxel`.
  - Documented the new `ElastomerTaxel` `normal_exponent` parameter (default `2.0`, HydroShear quadratic normal response).
  - Removed `probe_radius_noise` from the imperfections table and example: the option was removed from the base `ProbeSensorOptionsMixin`.

- **`source/user_guide/sensing/proximity.md`**
  - `probe_radius` default corrected from 10.0 m to 0.5 m (`SurfaceDistanceProbe`).
  - Replaced the removed `debug_sphere_radius` option with the new `debug_probe_center_radius` (0.0008 m) / `debug_probe_sphere_opacity` (0.3) debug-drawing options.

- **`source/user_guide/assets/mesh_processing.md`**
  - `watertighten` default corrected from 7 to 5 (`genesis/options/morphs.py`).

Left out (uncertain/low-value): a new edge-case note that `n_sample_points` per-link counts aren't split per-variant on heterogeneous entities — too deep in the weeds for the current guide's brief treatment, and doesn't contradict existing text.

---
_Opened as a draft by the weekly doc-check cron job. Review carefully before merging._
