### PR TITLE
Fix version switcher and minor cleanups

### DIFF
--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -25,6 +25,7 @@ html[data-theme="light"] {
   --pst-color-border: #e2e6e8;
   --pst-color-inline-code: #1a1d34;
   --pst-color-inline-code-links: #b32c2c;
+  --pst-color-accent: #b32c2c;
 }
 
 html[data-theme="dark"] {
@@ -42,10 +43,20 @@ html[data-theme="dark"] {
   --pst-color-border: #1c2030;
   --pst-color-inline-code: #dee8eb;
   --pst-color-inline-code-links: #ee8a8a;
+  --pst-color-accent: #ee8a8a;
 }
 
 .logo__image {
   padding: 0.35rem 0;
+}
+
+/* Match the search field's active state to the Genesis red accent (the theme's
+   default focus ring and border are purple/blue). --pst-color-accent above
+   already recolors the box-shadow ring; this fixes the hardcoded blue border. */
+.bd-search input:focus,
+.search-button__search-container input:focus,
+form.bd-search input:focus {
+  border-color: var(--pst-color-accent);
 }
 
 /* Left sidebar: the top-level entries are now real section landing pages, so

--- a/source/_static/version_switcher.json
+++ b/source/_static/version_switcher.json
@@ -1,6 +1,53 @@
 [
   {
+    "name": "latest",
     "version": "latest",
-    "url": "http://genesis-world.ai/docs/intro"
+    "url": "https://genesis-world.readthedocs.io/en/latest/",
+    "preferred": true
+  },
+  {
+    "name": "v1.2.2",
+    "version": "v1.2.2",
+    "url": "https://genesis-world.readthedocs.io/en/v1.2.2/"
+  },
+  {
+    "name": "v1.2.1",
+    "version": "v1.2.1",
+    "url": "https://genesis-world.readthedocs.io/en/v1.2.1/"
+  },
+  {
+    "name": "v1.0.0",
+    "version": "v1.0.0",
+    "url": "https://genesis-world.readthedocs.io/en/v1.0.0/"
+  },
+  {
+    "name": "v0.4.3",
+    "version": "v0.4.3",
+    "url": "https://genesis-world.readthedocs.io/en/v0.4.3/"
+  },
+  {
+    "name": "v0.3.14",
+    "version": "v0.3.14",
+    "url": "https://genesis-world.readthedocs.io/en/v0.3.14/"
+  },
+  {
+    "name": "v0.3.12",
+    "version": "v0.3.12",
+    "url": "https://genesis-world.readthedocs.io/en/v0.3.12/"
+  },
+  {
+    "name": "v0.3.10",
+    "version": "v0.3.10",
+    "url": "https://genesis-world.readthedocs.io/en/v0.3.10/"
+  },
+  {
+    "name": "v0.3.7",
+    "version": "v0.3.7",
+    "url": "https://genesis-world.readthedocs.io/en/v0.3.7/"
+  },
+  {
+    "name": "v0.3.3",
+    "version": "v0.3.3",
+    "url": "https://genesis-world.readthedocs.io/en/v0.3.3/"
   }
 ]

--- a/source/_static/version_switcher.json
+++ b/source/_static/version_switcher.json
@@ -11,11 +11,6 @@
     "url": "https://genesis-world.readthedocs.io/en/v1.2.2/"
   },
   {
-    "name": "v1.2.1",
-    "version": "v1.2.1",
-    "url": "https://genesis-world.readthedocs.io/en/v1.2.1/"
-  },
-  {
     "name": "v1.0.0",
     "version": "v1.0.0",
     "url": "https://genesis-world.readthedocs.io/en/v1.0.0/"
@@ -29,25 +24,5 @@
     "name": "v0.3.14",
     "version": "v0.3.14",
     "url": "https://genesis-world.readthedocs.io/en/v0.3.14/"
-  },
-  {
-    "name": "v0.3.12",
-    "version": "v0.3.12",
-    "url": "https://genesis-world.readthedocs.io/en/v0.3.12/"
-  },
-  {
-    "name": "v0.3.10",
-    "version": "v0.3.10",
-    "url": "https://genesis-world.readthedocs.io/en/v0.3.10/"
-  },
-  {
-    "name": "v0.3.7",
-    "version": "v0.3.7",
-    "url": "https://genesis-world.readthedocs.io/en/v0.3.7/"
-  },
-  {
-    "name": "v0.3.3",
-    "version": "v0.3.3",
-    "url": "https://genesis-world.readthedocs.io/en/v0.3.3/"
   }
 ]

--- a/source/conf.py
+++ b/source/conf.py
@@ -65,11 +65,14 @@ html_title = "Genesis World"
 # browsers prefer the crisp, theme-aware SVG.
 html_favicon = "_static/favicon.ico"
 
-# Load the switcher list from a single canonical location (the `latest` build)
-# rather than each version's own _static copy. This way every build that reads it
-# shows the same, complete version list, and the list is updated by editing one
-# file on `main` instead of rebuilding every version.
-json_url = "https://genesis-world.readthedocs.io/en/latest/_static/version_switcher.json"
+# On RTD, load the switcher list from a single canonical location (the `latest`
+# build) rather than each version's own _static copy, so every build shows the
+# same, complete list, maintained by editing one file on `main`. Locally, read the
+# in-tree copy instead so edits are previewable before they are deployed.
+if os.environ.get("READTHEDOCS"):
+    json_url = "https://genesis-world.readthedocs.io/en/latest/_static/version_switcher.json"
+else:
+    json_url = "_static/version_switcher.json"
 # On RTD this is the version slug being built (e.g. "latest", "v1.2.2"); it is
 # matched against the "version" field of each switcher entry to highlight the
 # active one. Falls back to the local package version for local builds.

--- a/source/conf.py
+++ b/source/conf.py
@@ -65,7 +65,14 @@ html_title = "Genesis World"
 # browsers prefer the crisp, theme-aware SVG.
 html_favicon = "_static/favicon.ico"
 
-json_url = "_static/version_switcher.json"
+# Load the switcher list from a single canonical location (the `latest` build)
+# rather than each version's own _static copy. This way every build that reads it
+# shows the same, complete version list, and the list is updated by editing one
+# file on `main` instead of rebuilding every version.
+json_url = "https://genesis-world.readthedocs.io/en/latest/_static/version_switcher.json"
+# On RTD this is the version slug being built (e.g. "latest", "v1.2.2"); it is
+# matched against the "version" field of each switcher entry to highlight the
+# active one. Falls back to the local package version for local builds.
 version_match = os.environ.get("READTHEDOCS_VERSION")
 if version_match is None:
     version_match = "v" + __version__

--- a/source/user_guide/configuration/initialization.md
+++ b/source/user_guide/configuration/initialization.md
@@ -85,20 +85,6 @@ gs.init(backend=gs.gpu, logging_level="warning")  # quiet: warnings and errors o
 
 Set `logger_verbose_time=True` to prefix each log line with a full timestamp instead of just the elapsed time. The `theme` argument (`"dark"`, `"light"`, or `"dumb"`) controls the terminal color scheme; use `"dumb"` to disable colors in environments that mangle ANSI codes.
 
-## Environment variables
-
-A few environment variables adjust backend and runtime behavior without changing your code, which is useful for CI, containers, and quick experiments:
-
-| Variable | Effect |
-|---|---|
-| `QD_ENABLE_<BACKEND>=0` | Skip a backend during `gs.gpu` resolution, e.g. `QD_ENABLE_METAL=0`. |
-| `GS_TORCH_FORCE_CPU_DEVICE=1` | Keep PyTorch tensors on the CPU even when the physics runs on a GPU. |
-| `QD_NUM_THREADS=N` | Cap the CPU thread and compile-thread count (defaults to 1 on CPU). |
-| `GS_ENABLE_NDARRAY=0` | Force static array mode in the compiler backend. |
-| `GS_ENABLE_ZEROCOPY=0/1` | Force zero-copy tensor sharing between PyTorch and the backend off or on. |
-
-For relocating the compilation caches (a separate concern, relevant to benchmarking), see {doc}`/user_guide/developers/profiling`.
-
 ## Performance mode
 
 With `performance_mode=True`, the compiler bakes static tensor shapes into its kernels for roughly 30% faster simulation, at the cost of recompiling whenever the scene changes (which can take several minutes). Leave it off for research, debugging, and interactive work; turn it on for policy training and production runs where the scene is fixed.

--- a/source/user_guide/index.md
+++ b/source/user_guide/index.md
@@ -9,8 +9,8 @@ overview/index
 getting_started/index
 configuration/index
 interaction/index
-robot_control/index
 physics/index
+robot_control/index
 sensing/index
 rendering/index
 assets/index


### PR DESCRIPTION
## Summary

Resolves https://github.com/Genesis-Embodied-AI/genesis-doc/issues/133

- **Version switcher**: rebuild `version_switcher.json` with all active Read the Docs versions, using correct per-version URLs (`https://genesis-world.readthedocs.io/en/<slug>/`) and slugs that match `READTHEDOCS_VERSION`. The old file had a single entry pointing at the marketing site, so none of the hosted versions were discoverable from the navbar dropdown. `latest` is marked as the preferred version.
- **Canonical switcher source**: load the switcher list from one canonical location (the `latest` build) instead of each version's own `_static` copy, so the list stays consistent across builds and is maintained by editing a single file on `main`.
- **Initialization page**: remove the Environment variables section.
- **User guide order**: place Physical Entities before Robot Control in the toctree.
- **Search styling**: match the search field's active border and focus ring to the Genesis red accent instead of the theme default purple.

## Notes / follow-ups (RTD admin, not in this repo)

- Already-built older tags baked in the previous config, so their navbar dropdown stays stale; RTD's own flyout menu still lists all versions on those builds. New releases inherit the fix automatically. Add each new release to `version_switcher.json` on `main` as part of the release checklist.
- There is a malformed tag `v.0.4.7` (extra dot) on RTD, omitted from the switcher: recommend deleting/deactivating it. Consider trimming very old `v0.3.x` versions too.