### PR TITLE
Link the API reference to the objects its docstrings name.

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -47,6 +47,10 @@ myst_enable_extensions = ["colon_fence", "dollarmath", "amsmath", "dollarmath"]
 # https://github.com/executablebooks/MyST-Parser/issues/519#issuecomment-1037239655
 myst_heading_anchors = 4
 
+# Single backticks in the docstrings resolve as Python cross-references, linking to the documented object when one
+# exists and rendering as inline code otherwise. Markdown pages are unaffected: MyST reads them as code spans.
+default_role = "py:obj"
+
 templates_path = ["_templates"]
 # exclude_patterns = ["user_guide/reference/_autosummary/*"]
 


### PR DESCRIPTION
## Description

Sets `default_role = "py:obj"` so that a single pair of backticks in a **docstring** resolves as a Python
cross-reference. Currently, single backtick converts to `title-reference`, which italicizes the name and links nothing.

With `py:obj`:

- a name the build can resolve becomes a link to its entry;
- a name it cannot resolve renders as inline code, exactly what the double pair produced.

Genesis-Embodied-AI/genesis-world#3144 documents the convention in `CODING_GUIDELINES.md` and `CLAUDE.md`, and should merge after this.

## Screenshot

<!-- Add a screenshot of the rendered page(s) this PR affects (before/after if helpful). -->

## Checklist

- [x] I read the [documentation style guide](STYLE_GUIDE.md) and followed it.
- [x] The docs build locally (`make html`) without new warnings.
