### PR TITLE
Update MouseInteractionPlugin parameter name.

### DIFF
--- a/source/user_guide/interaction/viewer_plugin.md
+++ b/source/user_guide/interaction/viewer_plugin.md
@@ -132,8 +132,8 @@ class MyPlugin(ViewerPlugin):
 ```python
 scene.viewer.add_plugin(
     gs.vis.viewer_plugins.MouseInteractionPlugin(
-        use_force=True,       # spring force; False sets position directly
-        spring_const=1000.0,  # N/m, only used when use_force=True
+        use_force=True,      # spring force; False sets position directly
+        spring_slack=0.02,   # distance in m the body hangs below the cursor; only used when use_force=True
         color=(0.1, 0.6, 0.8, 0.6),
     )
 )


### PR DESCRIPTION
The `MouseInteractionPlugin` snippet on the viewer plugin page still passes `spring_const`, which https://github.com/Genesis-Embodied-AI/genesis-world/pull/3143 replaces with `spring_slack`: the distance a grabbed link hangs below the cursor, from which the stiffness is derived using the mass of the link, so that every entity responds alike whatever it weighs.

Pairs with the submodule pointer bump in that pull request.