### PR TITLE
Select the link reference frame through the public enum.

### DIFF
--- a/source/api_reference/engine/solvers/rigid_solver.md
+++ b/source/api_reference/engine/solvers/rigid_solver.md
@@ -21,6 +21,14 @@ The values accepted by the `RigidOptions` fields above. The model each one selec
 .. autoclass:: genesis.constants.broadphase_traversal()
 ```
 
+## Reference frames
+
+The frame a per-link getter expresses its result in, and the frame an external wrench is read in.
+
+```{eval-rst}
+.. autoclass:: genesis.constants.link_ref_frame()
+```
+
 ## RigidSolver
 
 ```{eval-rst}

--- a/source/user_guide/getting_started/control_your_robot.md
+++ b/source/user_guide/getting_started/control_your_robot.md
@@ -214,7 +214,7 @@ and `RigidSolver.apply_links_external_wrench` take the same arguments plus a
 
 Three arguments decide where the wrench acts and in which coordinates it is read:
 
-- **`ref`:** the reference frame, either `"link_origin"` (default) or `"link_com"`, the link's center of mass. It selects the frame the input coordinates are expressed in, and the point the force acts at when you give no `pos`.
+- **`ref`:** the reference frame, either `gs.link_ref_frame.link_origin` (default) or `gs.link_ref_frame.link_COM`, the link's center of mass. It selects the frame the input coordinates are expressed in, and the point the force acts at when you give no `pos`.
 - **`local`:** by default the wrench is expressed in world coordinates. Set `local=True` to express it in the reference frame's own coordinates instead, so the force rotates with the link.
 - **`pos`:** the point the linear force acts at, which sets the moment arm of the torque it induces. With `local=True` it is an offset from the reference frame's origin, so the point follows the link as it moves. Otherwise it is a world position. A torque acts the same wherever it is applied, so `pos` requires a force.
 


### PR DESCRIPTION
## Description
`ref` now takes a `gs.link_ref_frame` member instead of a string literal, following Genesis-Embodied-AI/genesis-world#3143, so the external-wrench section quotes the enum members. The enum is public API, so it also gets an `autoclass` entry on the `RigidSolver` reference page, in its own section rather than under `Option enums`, which lists the values accepted by `RigidOptions` fields.

## Related PR
Genesis-Embodied-AI/genesis-world#3143
