### PR TITLE
Update stale docs references that the latest source does not support.

### DIFF
--- a/source/api_reference/engine/solvers/fem_solver.md
+++ b/source/api_reference/engine/solvers/fem_solver.md
@@ -1,6 +1,6 @@
 # FEMSolver
 
-The `FEMSolver` implements the Finite Element Method for simulating deformable solids on tetrahedral meshes. It supports several constitutive models (linear, stable Neo-Hookean, linear corotated), handles large deformations, and offers an explicit integrator by default with an optional implicit solver for stability at larger time steps. The materials it supports are listed in {doc}`/api_reference/engine/material/fem/index`. For usage, see {doc}`/user_guide/physics/beyond_rigid_bodies` and, for muscle-driven bodies, {doc}`/user_guide/physics/soft_robots`.
+The `FEMSolver` implements the Finite Element Method for simulating deformable solids on tetrahedral meshes. It supports several constitutive models (linear, stable Neo-Hookean, linear corotated), handles large deformations, and integrates explicitly unless `use_implicit_solver` selects the implicit solver, which stays stable at larger time steps. The materials it supports are listed in {doc}`/api_reference/engine/material/fem/index`. For usage, see {doc}`/user_guide/physics/beyond_rigid_bodies` and, for muscle-driven bodies, {doc}`/user_guide/physics/soft_robots`.
 
 ## Options
 

--- a/source/api_reference/utilities/device.md
+++ b/source/api_reference/utilities/device.md
@@ -1,46 +1,31 @@
 # Device and platform utilities
 
-Functions for detecting and configuring the compute platform and device.
+`gs.init()` resolves which compute backend Genesis World runs on and which PyTorch device holds the tensors it hands back, then publishes both as module-level globals.
 
-## Device information
+## Backend selection
+
+Pass `backend=gs.gpu` to take whichever GPU backend the machine has. Genesis World tries CUDA, then ROCm (`gs.amdgpu`), then Metal, then the CPU, and warns when it lands on the CPU because no GPU was available:
 
 ```python
 import genesis as gs
 
 gs.init(backend=gs.gpu)
 
-# Get PyTorch device
-device = gs.device
-print(device)  # cuda:0, mps:0, cpu, etc.
-
-# Get active backend
-backend = gs.backend
-print(backend)  # gs.cuda, gs.metal, gs.cpu, etc.
+print(gs.backend)  # the backend it settled on: gs.cuda, gs.amdgpu, gs.metal, or gs.cpu
+print(gs.device)  # the matching PyTorch device: cuda:0, mps:0, or cpu
 ```
 
-## Backend selection
-
-### Automatic selection
+Name a backend instead when a machine has more than one and the choice matters, or to compare a run against the CPU:
 
 ```python
-# Takes the first GPU backend available on the machine
-gs.init(backend=gs.gpu)
-# tried in order: gs.cuda -> gs.amdgpu -> gs.metal -> gs.cpu
+gs.init(backend=gs.cuda)  # NVIDIA CUDA
+gs.init(backend=gs.metal)  # Apple Metal
+gs.init(backend=gs.cpu)  # every platform
 ```
 
-With none of the three available, `gs.gpu` falls back to `gs.cpu` and logs a warning. Read `gs.backend` after
-`gs.init()` to see what it settled on.
+A named backend that the machine cannot provide raises instead of falling back, so a run meant for the GPU fails at `gs.init()` rather than silently simulating on the CPU.
 
-### Manual selection
-
-```python
-# Force specific backend
-gs.init(backend=gs.cuda)    # NVIDIA CUDA
-gs.init(backend=gs.metal)   # Apple Metal
-gs.init(backend=gs.cpu)     # CPU fallback
-```
-
-### Backend
+## Backend
 
 ```{eval-rst}
 .. autoclass:: genesis.constants.backend()
@@ -53,30 +38,17 @@ gs.init(backend=gs.cpu)     # CPU fallback
 .. autofunction:: genesis.utils.misc.set_random_seed
 ```
 
-## Global variables
+## Globals set by `gs.init()`
 
-After `gs.init()`, these are available:
+| Global | Type | Holds |
+|---|---|---|
+| `gs.device` | `torch.device` | The PyTorch device every returned tensor lives on (`cuda:0`, `mps:0`, `cpu`). |
+| `gs.backend` | `gs.backend` | The backend that was selected, after resolving `gs.gpu`. |
+| `gs.EPS` | `float` | Numerical epsilon for the active float precision. |
 
-| Variable | Type | Description |
-|----------|------|-------------|
-| `gs.device` | torch.device | PyTorch device for tensors |
-| `gs.backend` | gs.backend | Active compute backend |
-| `gs.EPS` | float | Machine epsilon for the current precision |
-
-## Type hints
-
-```python
-# Quadrants types
-gs.qd_float  # Quadrants float type
-gs.qd_int    # Quadrants int type
-gs.qd_vec3   # Quadrants 3D vector
-gs.qd_mat3   # Quadrants 3x3 matrix
-
-# PyTorch types
-gs.tc_float  # PyTorch float dtype
-gs.tc_int    # PyTorch int dtype
-```
+The `precision` argument decides the float width, and the dtype aliases follow it: `gs.qd_float`, `gs.np_float`, and `gs.tc_float` are the Quadrants, NumPy, and PyTorch float types, resolving to 32-bit under the default `precision="32"` and 64-bit under `precision="64"`. Integer aliases (`gs.qd_int`, `gs.np_int`, `gs.tc_int`) stay 32-bit at either precision, and `gs.qd_vec3` and `gs.qd_mat3` are the Quadrants vector and matrix types built on `gs.qd_float`. Use the aliases rather than a literal `torch.float32` so a scene keeps working when its precision changes.
 
 ## See also
 
-- {doc}`tensor_utils`: Tensor operations
+- {doc}`tensor_utils`: converting between Quadrants fields, PyTorch tensors, and NumPy arrays.
+- {doc}`/user_guide/configuration/initialization`: what `gs.init()` sets up, and the other arguments it takes.

--- a/source/api_reference/utilities/index.md
+++ b/source/api_reference/utilities/index.md
@@ -11,9 +11,9 @@ Genesis World bundles a set of helper modules under `genesis.utils` for the oper
 - **{doc}`file_io`:** cache and source directory paths, plus loading URDF and MJCF descriptions.
 - **{doc}`tools`:** timing loops and saving media in `genesis.utils.tools`.
 
-## Initialization and globals
+## Initialization
 
-Most utilities assume the library has been initialized. `gs.init()` selects the backend, sets the random seed and float precision, and populates the module-level globals below.
+Most utilities assume the library has been initialized. `gs.init()` selects the backend, sets the random seed and the float precision, and publishes the resolved configuration as module-level globals:
 
 ```python
 import genesis as gs
@@ -25,13 +25,7 @@ gs.init(
 )
 ```
 
-After `gs.init()` returns, these globals hold the resolved configuration:
-
-| Global | Type | Description |
-|---|---|---|
-| `gs.device` | `torch.device` | The active PyTorch device (for example, `cuda:0`, `mps:0`, or `cpu`). |
-| `gs.backend` | backend enum | The backend that was actually selected, after resolving `gs.gpu`. |
-| `gs.EPS` | `float` | Numerical epsilon for the active float precision. |
+{doc}`device` covers the backend resolution, the globals it sets (`gs.device`, `gs.backend`, `gs.EPS`), and the precision-dependent dtype aliases.
 
 ## Components
 

--- a/source/user_guide/configuration/checkpoints.md
+++ b/source/user_guide/configuration/checkpoints.md
@@ -126,7 +126,7 @@ On disk, a checkpoint is a pickled dictionary. The `arrays` entry is a flat map 
 ## Reproducibility notes
 
 - **Configuration must match.** A checkpoint restores fields by name into an already-built scene. The entities, solver options, and environment count must match the scene that produced it. There is no compatibility check: a mismatch fails or silently corrupts state.
-- **Precision limits exactness.** Genesis World uses 32-bit floats by default (see {doc}`Hello, Genesis World </user_guide/getting_started/hello_genesis>`). A save/load round trip is therefore accurate to roughly single-precision, not bit-exact. Build with `precision="64"` if you need tighter reproducibility.
+- **Precision limits exactness.** Genesis World uses 32-bit floats by default (see {doc}`initialization`). A save/load round trip is therefore accurate to roughly single-precision, not bit-exact. Initialize with `precision="64"` if you need tighter reproducibility.
 - **Serialize before pickling a `SimState`.** A `SimState` returned by `get_state()` holds live references back into the scene and its autograd graph. Call `state.serializable()` first to detach the tensors and drop those references, then pickle it yourself. `save_checkpoint` handles this for you.
 
 ```python
@@ -142,5 +142,3 @@ with open("state.pkl", "wb") as f:
 
 - {doc}`Parallel simulation </user_guide/getting_started/parallel_simulation>`: how state is batched over environments.
 - {doc}`Scene API </api_reference/engine/scene>`: the full signatures of `get_state`, `reset`, `save_checkpoint`, and `load_checkpoint`.
-</content>
-</invoke>

--- a/source/user_guide/configuration/config_system.md
+++ b/source/user_guide/configuration/config_system.md
@@ -40,9 +40,9 @@ All `gs.options.*` classes derive from {py:class}`gs.options.Options <genesis.op
 
 You never instantiate `Options` directly; you always use a concrete subclass. Each option class is documented in the {doc}`API Reference </api_reference/index>` alongside the component it configures.
 
-## Simulator options override solver options
+## Solver options override simulator options
 
-`SimOptions` holds settings that are global by default: most importantly the timestep `dt` (seconds) and `gravity` (N/kg, pointing down `-Z`). Each solver also exposes those same settings on its own options object, where they default to `None`.
+`SimOptions` holds settings that are global by default: most importantly the timestep `dt` (seconds) and `gravity` (m/s², pointing down `-Z`). Each solver also exposes those same settings on its own options object, where they default to `None`.
 
 The rule is: **a value set on a solver's options overrides the global `SimOptions` value, for that solver only.** A solver whose field is left at `None` inherits the global value. This lets most scenes set `dt` once while allowing a single solver to run at a different rate.
 

--- a/source/user_guide/getting_started/parallel_simulation.md
+++ b/source/user_guide/getting_started/parallel_simulation.md
@@ -73,7 +73,7 @@ The same `envs_idx` argument is available on the state-reading methods (for exam
 Genesis World supports tens of thousands of environments on a single GPU. Turn off the viewer for headless throughput and raise `n_envs`; memory use grows with the batch, so reduce it if your GPU runs out of VRAM. To measure throughput on your own hardware, use the scripts in [`examples/speed_benchmark`](https://github.com/Genesis-Embodied-AI/genesis-world/tree/main/examples/speed_benchmark) and see {doc}`/user_guide/developers/profiling`.
 
 :::{tip}
-Genesis World prints the real-time simulation speed (FPS) to the terminal by default. Disable it by setting `scene.profiling_options.show_FPS = False` when creating the scene.
+Genesis World prints the real-time simulation speed (FPS) to the terminal by default. Disable it by setting `profiling_options=gs.options.ProfilingOptions(show_FPS=False)` when creating the scene.
 :::
 
 ## See also

--- a/source/user_guide/interaction/viewer_plugin.md
+++ b/source/user_guide/interaction/viewer_plugin.md
@@ -121,7 +121,7 @@ class MyPlugin(ViewerPlugin):
         return None
 
     def on_draw(self) -> None:
-        # Debug geometry drawn here is cleared and redrawn each frame.
+        self.scene.clear_debug_objects()  # debug geometry persists, so clear last frame's first
         self.scene.draw_debug_sphere((0.0, 0.0, 1.0), radius=0.05)
 ```
 

--- a/source/user_guide/overview/installation.md
+++ b/source/user_guide/overview/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Genesis World installs from PyPI in two steps: install PyTorch, then install Genesis World. It runs on Linux, macOS, and Windows, on CPU and on CUDA and non-CUDA GPUs.
+Genesis World installs from PyPI in two steps: install PyTorch, then install Genesis World. It runs on Linux, macOS, and Windows, on the CPU and on NVIDIA, AMD, and Apple Silicon GPUs.
 
 ## Install
 
@@ -23,16 +23,16 @@ To run on CUDA, make sure a matching NVIDIA driver is installed on your machine.
 - **Python:** 3.10 to 3.13 (`>=3.10,<3.14`).
 - **Operating system:** Linux, macOS, or Windows. Linux with a CUDA-compatible GPU gives the best performance.
 
-Genesis World is cross-platform across CPU, CUDA GPUs, and non-CUDA GPUs. The following combinations are supported:
+Genesis World simulates on the CPU (`gs.cpu`) and on NVIDIA (`gs.cuda`), AMD (`gs.amdgpu`), and Apple Silicon (`gs.metal`) GPUs, with `gs.gpu` resolving to whichever of the three your machine has. An Intel GPU drives the viewer and offscreen rendering but has no simulation backend, so run the physics on `gs.cpu` there. The following combinations are supported:
 
 | OS | GPU | GPU simulation | CPU simulation | Interactive viewer | Headless rendering |
 |---|---|:---:|:---:|:---:|:---:|
 | Linux | Nvidia | ✅ | ✅ | ✅ | ✅ |
 | Linux | AMD | ✅ | ✅ | ✅ | ✅ |
-| Linux | Intel | ✅ | ✅ | ✅ | ✅ |
+| Linux | Intel | ❌ | ✅ | ✅ | ✅ |
 | Windows | Nvidia | ✅ | ✅ | ✅ | ✅ |
 | Windows | AMD | ✅ | ✅ | ✅ | ✅ |
-| Windows | Intel | ✅ | ✅ | ✅ | ✅ |
+| Windows | Intel | ❌ | ✅ | ✅ | ✅ |
 | macOS | Apple Silicon | ✅ | ✅ | ✅ | ✅ |
 
 ## Optional components

--- a/source/user_guide/overview/what_is_genesis.md
+++ b/source/user_guide/overview/what_is_genesis.md
@@ -11,7 +11,7 @@ Genesis World began as an academic project in December 2024, under the name **Ge
 Genesis World occupies four layers. Above it sits whatever you build: robotics environments, ML pipelines, or agentic simulation. Below it sits whatever compute backend you have.
 
 - **Simulation interface:** the user-facing API for asset parsing (URDF, MJCF, OBJ, GLB, USD, …), entity accessors, controllers, sensors, parallel and heterogeneous environments, and a built-in viewer.
-- **Physics:** a unified multi-physics engine integrating rigid, FEM, MPM, and particle (PBD/SPH) solvers, [uipc](https://github.com/spiriMirror/libuipc), an explicit coupler, and SAP, all sharing one scene and one state.
+- **Physics:** a unified multi-physics engine integrating rigid, FEM, MPM, and particle (PBD/SPH) solvers, with explicit, SAP, and [libuipc](https://github.com/spiriMirror/libuipc)-based couplers resolving contact between them, all sharing one scene and one state.
 - **Render:** three rendering paths behind the cameras. [Nyx](https://github.com/Genesis-Embodied-AI/genesis-nyx) is an in-house renderer built for robotics, Luisa is a DSL ray tracer, and Pyrender is a rasterizer.
 - **Compiler:** [Quadrants](https://github.com/Genesis-Embodied-AI/quadrants) lowers Python kernel code to CUDA, AMD ROCm, Apple Metal, Vulkan, x86, and ARM64. It carries the autodiff, GPU-graph, and fast-cache machinery.
 

--- a/source/user_guide/physics/hybrid_entity.md
+++ b/source/user_guide/physics/hybrid_entity.md
@@ -37,7 +37,7 @@ scene = gs.Scene(
 )
 ```
 
-The MPM solver simulates the skin on a background grid; `lower_bound` and `upper_bound` (meters) define that grid, and anything that leaves it is lost. Keep the entity comfortably inside.
+The MPM solver simulates the skin on a background grid; `lower_bound` and `upper_bound` (meters) define that grid's extent. Keep the entity comfortably inside.
 
 ## Add the hybrid entity
 
@@ -112,7 +112,7 @@ The rigid and soft solvers must share the same `dt`. Genesis World asserts this 
 :::
 
 :::{warning}
-The MPM grid defined by `lower_bound` / `upper_bound` is finite. Particles that move outside it are dropped, which shows up as skin tearing away from the skeleton. Size the bounds to contain the entity's full range of motion.
+The MPM grid defined by `lower_bound` / `upper_bound` is finite, and the solver clamps a skin particle that reaches the edge, which shows up as the skin catching on an invisible wall while the skeleton moves on. Size the bounds to contain the entity's full range of motion.
 :::
 
 :::{tip}

--- a/source/user_guide/physics/soft_robots.md
+++ b/source/user_guide/physics/soft_robots.md
@@ -74,7 +74,7 @@ scene = gs.Scene(
 )
 ```
 
-The MPM solver discretizes space onto a background grid; `lower_bound` and `upper_bound` set its extent in meters (Z-up). Any particle that leaves the grid is lost, so size the bounds to contain the robot's full range of motion.
+The MPM solver discretizes space onto a background grid; `lower_bound` and `upper_bound` set its extent in meters (Z-up). A particle that reaches the edge is clamped there and loses its velocity into the wall, so size the bounds to contain the robot's full range of motion.
 
 ## Muscle groups and fiber directions
 

--- a/source/user_guide/policy_training/examples/manipulation.md
+++ b/source/user_guide/policy_training/examples/manipulation.md
@@ -85,7 +85,7 @@ The gripper stays open throughout the learned rollout. The policy's job is to al
 
 ### Reward
 
-A single reward term drives learning: keypoint alignment. Reference keypoints are attached to both the gripper and the object, and the reward shrinks as the two sets of keypoints coincide:
+A single reward term drives learning: keypoint alignment. Reference keypoints are attached to both the gripper and the object, and the reward grows as the two sets of keypoints coincide:
 
 ```python
 reward_scales = {

--- a/source/user_guide/rendering/index.md
+++ b/source/user_guide/rendering/index.md
@@ -108,7 +108,7 @@ Two light types are available:
 Ambient light is a separate, uniform fill set through the `ambient_light` field rather than an entry in `lights`.
 
 :::{note}
-This controls the rasterizer only. The ray tracer has no light objects: lights there are entities with an {py:class}`Emission <genesis.options.surfaces.Emission>` surface, covered in {doc}`Surfaces and textures <surfaces_textures>`. The `BatchRenderer` backend instead takes lights at runtime through `scene.add_light(...)`.
+This controls the rasterizer only. The ray tracer ignores `VisOptions.lights` and lights the scene from three sources of its own: the `lights` list of sphere area lights on `gs.renderers.RayTracer(...)`, its `env_surface` environment map, and any entity carrying an {py:class}`Emission <genesis.options.surfaces.Emission>` surface, covered in {doc}`Surfaces and textures <surfaces_textures>`. The `BatchRenderer` backend instead takes lights at runtime through `scene.add_light(...)`.
 :::
 
 ## Rendering backends

--- a/source/user_guide/robot_control/inverse_kinematics_motion_planning.md
+++ b/source/user_guide/robot_control/inverse_kinematics_motion_planning.md
@@ -8,7 +8,7 @@ The complete script is [`examples/tutorials/IK_motion_planning_grasp.py`](https:
 :alt: A Franka arm positioned above a small cube on the ground plane, viewed in the Genesis World viewer.
 ```
 
-Motion planning uses the [OMPL](https://ompl.kavrakilab.org/) library. Install it with the instructions on the {doc}`installation </user_guide/overview/installation>` page before running the example.
+Motion planning runs on the sampling-based planners built into Genesis World, so the example needs no extra dependency. See {doc}`path_planning` for the planners and their parameters.
 
 ## Scene and robot setup
 

--- a/source/user_guide/robot_control/path_planning.md
+++ b/source/user_guide/robot_control/path_planning.md
@@ -112,7 +112,7 @@ When the mask is not requested, a failed plan still returns a path-shaped tensor
 
 ## Planning across parallel environments
 
-In a {doc}`batched scene </user_guide/getting_started/parallel_simulation>`, `plan_path` plans for every environment at once. The returned tensor gains a leading environment dimension:
+In a {doc}`batched scene </user_guide/getting_started/parallel_simulation>`, `plan_path` plans for every environment at once. The returned tensor gains an environment dimension between the waypoint and joint dimensions:
 
 ```python
 scene.build(n_envs=16)

--- a/source/user_guide/sensing/camera_sensors.md
+++ b/source/user_guide/sensing/camera_sensors.md
@@ -78,7 +78,7 @@ Three backends render RGB. They share the common options below and differ in spe
 | {py:class}`RaytracerCameraOptions <genesis.options.sensors.camera.RaytracerCameraOptions>` | LuisaRender | single environment | photo-realistic offline renders |
 | {py:class}`BatchRendererCameraOptions <genesis.options.sensors.camera.BatchRendererCameraOptions>` | Madrona (GPU) | parallel | high-throughput RL training (CUDA only) |
 
-Select a backend by choosing the matching options class; no separate scene `renderer` argument is required for the rasterizer. For photo-realistic path tracing, prefer the Nyx renderer described in {doc}`/user_guide/rendering/nyx_renderer`.
+Select a backend by choosing the matching options class. The rasterizer and the batch renderer set themselves up from it, while a raytracer camera also needs its renderer on the scene, `gs.Scene(renderer=gs.renderers.RayTracer(...))`, and raises at build time without it. For photo-realistic path tracing, prefer the Nyx renderer described in {doc}`/user_guide/rendering/nyx_renderer`.
 
 Common parameters (all backends):
 

--- a/source/user_guide/sensing/raycaster.md
+++ b/source/user_guide/sensing/raycaster.md
@@ -90,8 +90,6 @@ gs.sensors.SphericalPattern(
 )
 ```
 
-**First mention of SphericalPattern:**
-
 To model a real unit, set the fov and ray counts from its datasheet. For example, a Velodyne VLP-16 is `fov=(360.0, 30.0), n_points=(1800, 16)`.
 
 ### DepthCameraPattern

--- a/source/user_guide/theory/soft_solvers.md
+++ b/source/user_guide/theory/soft_solvers.md
@@ -14,7 +14,7 @@ To pick a solver and run one, see {doc}`/user_guide/physics/beyond_rigid_bodies`
 | **SPH** (Smoothed-Particle Hydrodynamics) | Free-surface liquids | Particles |
 | **SF** (Stable Fluids) | Smoke and gas | Fixed Eulerian grid |
 
-A **kinematic** solver for scripted motion and a **tool** solver for driven manipulators round out the set. Both participate in coupling, and neither is selected through a material.
+A **kinematic** solver for scripted motion and a **tool** solver for driven manipulators round out the set, and a material selects them as it does the five above: `gs.materials.Kinematic` and `gs.materials.Tool`. The tool solver drives the soft solvers through one-way coupling, while a kinematic entity is rendered only and takes no part in physics.
 
 ## Deformation and stress
 


### PR DESCRIPTION
## Description

Every claim below was checked against the engine source, with the file and line recorded in the commit message.

**Platform and backends.** The support table marked Intel GPUs as capable of GPU simulation, but the backend enum is `cpu`/`cuda`/`amdgpu`/`metal` and `get_device` raises for anything Torch does not expose as CUDA, HIP, or MPS, so an Intel GPU drives the viewer and rendering only. The device page now also states that a named backend raises rather than falling back, that `gs.gpu` falls back and warns, and how `precision` maps onto the dtype aliases.

**Engine behavior**, nine claims:

- A particle that reaches the edge of the MPM grid is clamped there with its velocity zeroed, rather than dropped (`CubeBoundary.impose_pos_vel`). This was on three pages.
- The kinematic and tool solvers are selected by a material like the other five, through `gs.materials.Kinematic` and `gs.materials.Tool`.
- FEM integrates explicitly unless `use_implicit_solver` says otherwise.
- A raytracer camera sensor raises at build time without `gs.Scene(renderer=gs.renderers.RayTracer(...))`.
- The ray tracer ignores `VisOptions.lights` and takes its own three sources instead.
- `plan_path` returns the environment dimension between the waypoint and joint dimensions, not in front of them.
- Gravity is in m/s², not N/kg.
- The keypoint reward grows as the keypoints align, which is what the code sample directly beneath it already showed.
- One heading on the options page said the opposite of the rule stated two lines below it.

**Stale references and leaked text.** Motion planning has not used OMPL since the sampling-based planners moved in-tree, so the tutorial no longer sends readers to install it. `profiling_options` is a `gs.Scene` argument rather than an attribute to assign afterwards, and `precision` is a `gs.init` argument rather than a build one. The viewer-plugin `on_draw` example claimed the viewer clears debug geometry each frame, which leaks a sphere per frame; it now calls `clear_debug_objects` as the prose 60 lines below already instructed. An editing note and a pair of tool-call tags had been published verbatim on the raycaster and checkpoint pages.

## Screenshot

Prose-only changes to existing pages; no layout or rendering changes.

## Checklist

- [x] I read the [documentation style guide](STYLE_GUIDE.md) and followed it.
- [x] The docs build locally (`make html`) without new warnings. A clean build reports 17 warnings, all pre-existing autodoc warnings from engine docstrings, none from `source/`.
