### PR TITLE
Document per-solver gravity, the interval a solver integrates over, and the mass and center of mass setters.

### DIFF
--- a/source/api_reference/engine/scene.md
+++ b/source/api_reference/engine/scene.md
@@ -1,12 +1,18 @@
 # Scene
 
-The `Scene` is the top-level container for a simulation: add entities to it, build it, then step it. It is assembled from a bundle of options passed to `gs.Scene(...)`, each documented with the component it configures: `sim_options` (the {doc}`Simulator <simulator>`), the per-solver options (with each {doc}`solver <solvers/index>`), `coupler_options` (the {doc}`coupler <couplers/index>`), `viewer_options` and `vis_options` (the {doc}`viewer </api_reference/visualization/viewer>`), `renderer` (the {doc}`renderer </api_reference/visualization/renderers/index>`), and `profiling_options` below. For a worked example, see {doc}`/user_guide/getting_started/hello_genesis`.
+The `Scene` is the top-level container for a simulation: add entities to it, build it, then step it. It is assembled from a bundle of options passed to `gs.Scene(...)`, each documented with the component it configures: `sim_options` (the {doc}`Simulator <simulator>`), the per-solver options (with each {doc}`solver <solvers/index>`), `coupler_options` (the {doc}`coupler <couplers/index>`), `viewer_options` and `vis_options` (the {doc}`viewer </api_reference/visualization/viewer>`), `renderer` (the {doc}`renderer </api_reference/visualization/renderers/index>`), and `profiling_options` below. Every option a scene is created with is held as one `SceneOptions` object, reachable as `scene.options` and documented below. For a worked example, see {doc}`/user_guide/getting_started/hello_genesis`.
 
 ```{eval-rst}
 .. autoclass:: genesis.engine.scene.Scene
     :members:
     :undoc-members:
     :show-inheritance:
+```
+
+## Scene options
+
+```{eval-rst}
+.. autoclass:: genesis.options.scene.SceneOptions
 ```
 
 ## Profiling options

--- a/source/api_reference/recording/file_writers.md
+++ b/source/api_reference/recording/file_writers.md
@@ -1,6 +1,6 @@
 # File writers
 
-A file writer records sampled data to disk. Pass one as the `rec_options` argument of `scene.start_recording`, and the recorder manager samples your data function on schedule and writes each sample to the file. See {doc}`index` for the recording workflow and the shared options (`hz`, `buffer_size`, `save_on_reset`) that every writer inherits.
+A file writer records sampled data to disk. Pass one as the `rec_options` argument of `scene.add_recorder`, and the recorder manager samples your data function on schedule and writes each sample to the file. See {doc}`index` for the recording workflow and the shared options (`hz`, `buffer_size`, `save_on_reset`) that every writer inherits.
 
 ## `gs.recorders.NPZFile`
 
@@ -41,7 +41,25 @@ Encodes a stream of image frames to a video file. Pair it with a data function t
     :show-inheritance:
 ```
 
+## `gs.recorders.TrajectoryFile`
+
+Records the state of the scene itself, one frame per step, to a `.gstraj` file. Register it with `scene.start_recording`, which takes the options alone since the scene is the data source, and open the file with `gs.Scene.load_trajectory` to seek and replay it. See {doc}`/user_guide/configuration/checkpoints` for the workflow.
+
+```{eval-rst}
+.. autoclass:: genesis.options.recorders.TrajectoryFile
+
+.. autoclass:: genesis.recorders.trajectory.TrajectoryFileWriter
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: genesis.recorders.trajectory.Trajectory
+    :members:
+    :undoc-members:
+```
+
 ## See also
 
 - {doc}`index`: the recording workflow and shared recorder options.
 - {doc}`plotters`: live plotting instead of writing to a file.
+- {doc}`/user_guide/configuration/checkpoints`: checkpoints and trajectories of a scene.

--- a/source/api_reference/recording/index.md
+++ b/source/api_reference/recording/index.md
@@ -8,7 +8,7 @@ For the recording workflow and worked examples, see {doc}`/user_guide/sensing/re
 
 - **Recorder:** the base class that processes each sampled value. See {doc}`recorder`.
 - **RecorderManager:** the per-scene coordinator that drives every registered recorder as the scene builds, steps, and resets. See {doc}`recorder_manager`.
-- **File writers:** `NPZFile`, `CSVFile`, and `VideoFile` persist data to disk. See {doc}`file_writers`.
+- **File writers:** `NPZFile`, `CSVFile`, and `VideoFile` persist data to disk, and `TrajectoryFile` records the scene itself for replay. See {doc}`file_writers`.
 - **Plotters:** `PyQtLinePlot`, `MPLLinePlot`, `MPLImagePlot`, and `MPLVectorFieldPlot` visualize data live and can save the animation. See {doc}`plotters`.
 
 Every recorder options class is exported from `gs.recorders`.
@@ -36,4 +36,4 @@ Every recorder options class inherits these fields from `RecorderOptions`.
 
 - {doc}`/user_guide/sensing/recorders`: task-oriented guide to recording sensor and custom data.
 - {doc}`/api_reference/visualization/index`: cameras and other visual output.
-- {doc}`/api_reference/engine/index`: `scene.start_recording` and `scene.stop_recording`.
+- {doc}`/api_reference/engine/index`: `scene.add_recorder`, `scene.start_recording`, and `scene.stop_recording`.

--- a/source/api_reference/recording/plotters.md
+++ b/source/api_reference/recording/plotters.md
@@ -1,6 +1,6 @@
 # Plotters
 
-A plotter visualizes sampled data live as the scene steps, and can save the animation. Pass one as the `rec_options` argument of `scene.start_recording`. See {doc}`index` for the recording workflow and the shared options (`hz`, `buffer_size`) that every plotter inherits.
+A plotter visualizes sampled data live as the scene steps, and can save the animation. Pass one as the `rec_options` argument of `scene.add_recorder`. See {doc}`index` for the recording workflow and the shared options (`hz`, `buffer_size`) that every plotter inherits.
 
 A data function that returns a `dict` becomes one labeled subplot per key.
 

--- a/source/api_reference/recording/recorder_manager.md
+++ b/source/api_reference/recording/recorder_manager.md
@@ -15,5 +15,5 @@ For the recording workflow, registering recorders, and camera video capture, see
 
 - {doc}`/user_guide/sensing/recorders`: task-oriented guide to recording.
 - {doc}`recorder`: base recorder class.
-- {doc}`file_writers` and {doc}`plotters`: the recorder options you pass to `start_recording`.
-- {doc}`/api_reference/engine/scene`: `scene.start_recording` and `scene.stop_recording`.
+- {doc}`file_writers` and {doc}`plotters`: the recorder options you pass to `add_recorder`.
+- {doc}`/api_reference/engine/scene`: `scene.add_recorder`, `scene.start_recording`, and `scene.stop_recording`.

--- a/source/user_guide/configuration/checkpoints.md
+++ b/source/user_guide/configuration/checkpoints.md
@@ -2,12 +2,14 @@
 
 A simulation has two things worth keeping. The first is its *dynamic state*: the numbers the physics solvers advance every step, such as joint positions, velocities, and particle fields. Capturing that state and restoring it later lets you rewind a simulation or reset an environment between episodes, deterministically, from the exact state you left. The second is the *scene itself*: the entities, their geometry, and every option the scene was created with. Writing that to a file lets someone else open the very scene you built, on a machine holding none of the assets you built it from.
 
-Genesis World keeps the two apart, because they answer different needs.
+Genesis World offers four ways to keep them, which answer different needs.
 
 - **Dynamic state, in memory:** `scene.get_state()` returns a {py:class}`SimState <genesis.engine.states.solvers.SimState>` object, and `scene.reset(state=...)` writes it back. Fast, and the basis of episode resets in reinforcement learning.
+- **The whole scene and its state, in memory:** the pickle protocol. `pickle.dumps(scene)` gives a built copy that steps on exactly as the original, and `scene.__getstate__()` and `scene.__setstate__()` save and restore a built scene in place. Use it to checkpoint a run, or to hand a scene to another process.
 - **The scene, on disk:** `scene.export(path)` writes a `.gscene` file, and `gs.Scene.load(path)` opens it into a new scene, ready to build. Use it to share a scene, attach one to a bug report, or rebuild one without its assets.
+- **A run, on disk:** `scene.save_checkpoint(path)` writes the scene with every array of its simulation, and `scene.start_recording(gs.recorders.TrajectoryFile(...))` writes a frame per step. `gs.Scene.load_checkpoint(path)` and `gs.Scene.load_trajectory(path)` open them in a built scene, to resume, seek, and replay, on any machine and backend.
 
-A state snapshot assumes the scene it came from is already built. A scene file carries no simulated state, so a scene opened from one stands at the configuration its entities were given, and the state has to be reproduced by stepping it again.
+A state snapshot assumes the scene it came from is already built. A scene file carries no simulated state, so a scene opened from one stands at the configuration its entities were given, and the state has to be reproduced by stepping it again. A checkpoint or a trajectory carries both, so the scene it opens stands where the recorded one stood.
 
 ## State model
 
@@ -99,12 +101,84 @@ Adding an entity resolves its description, so a scene is exported before it is b
 
 The file names what it holds rather than carrying code to run. Genesis World creates only the options, descriptions and meshes the file declares, and rejects a value that contradicts its declared type, so a scene from a stranger is safe to open. A load also compares the layout of every class the file holds with the current one, and refuses a file written when a class meant something else, naming the class. A file written by another version of Genesis World whose classes still match loads with a warning that the simulation it describes may run differently.
 
-Every option the scene was created with travels as one {py:class}`SceneOptions <genesis.options.scene.SceneOptions>` object, reachable as `scene.options` on any scene. Passing it to `gs.Scene(options=other.options)` creates a scene from what another was created with, which is also how a loaded scene gets its options back.
+Every option the scene was created with travels as one {py:class}`SceneOptions <genesis.options.scene.SceneOptions>` object, reachable as `scene.options` on any scene. Passing it to `gs.Scene(options=other.options)` creates a scene from what another was created with, which is also how a loaded scene gets its options back. The physics options stand as recorded, since they size the arrays a recorded state fills, and the viewer, visualizer, and renderer options may be replaced at load, so a scene recorded headless opens in the viewer a debugging session needs:
+
+```python
+scene = gs.Scene.load(
+    "franka.gscene",
+    show_viewer=True,
+    viewer_options=gs.options.ViewerOptions(camera_pos=(2.0, 1.5, 1.0), camera_lookat=(0.0, 0.0, 0.3)),
+)
+```
 
 What a description carries is what travels, and `export` tells you about the rest:
 
 - **Refused, by name:** anything that alters the simulation and that a description leaves out, since a file without it would restore other physics: an emitter, a force field, and any entity that carries no description, which is every entity that is neither rigid nor kinematic.
 - **Written without, with a warning naming it:** what observes or draws the simulation rather than shaping it. A camera, a recorder, a sensor, a callback Genesis World calls at every step, a texture read from an HDR or EXR file, and the visual vertices an entity was given at runtime. Add those back on the loaded scene.
+
+## Checkpointing a built scene
+
+A `SimState` holds what you read back as positions and velocities. A **checkpoint** holds everything a step reads from one step to the next: the reduced-space state and the control inputs, the contacts and the constraint solution, the warm-start caches, and the link and geom poses the last step derived. Stepping a restored scene therefore lands bit-for-bit where the original went, on every backend.
+
+The checkpoint is the pickle protocol. `scene.__getstate__()` returns a {py:class}`SceneCheckpoint <genesis.engine.scene.SceneCheckpoint>`: the scene description, the environment layout the scene was built with, and the arrays of every solver, copied where they live, so a save and a restore within one process stay on the device. `scene.__setstate__(checkpoint)` puts a scene built from the same description and layout back in that state, and rejects a checkpoint from another build by the name of what differs. Pickling a scene reads the same record, and unpickling creates and builds the scene before restoring it:
+
+```python
+import pickle
+
+scene.build(n_envs=16)
+for _ in range(100):
+    scene.step()
+
+checkpoint = scene.__getstate__()  # a device-resident copy of the state at step 100
+twin = pickle.loads(pickle.dumps(scene))  # a built copy of the scene, standing at step 100
+
+for _ in range(50):
+    scene.step()
+scene.__setstate__(checkpoint)  # back to step 100, and the next 50 steps land where they did
+```
+
+A restore also restarts what surrounds the state, as a reset does: the gradient tape, the sensors, and the recorders forget the run that led there, and the viewer redraws. The simulated time of each environment comes back as recorded, since it is state. A differentiable scene carries the gradients of its arrays along, so a checkpoint taken after a backward pass restores them.
+
+## Checkpoint and trajectory files
+
+`scene.save_checkpoint(path)` writes a `.gstraj` file holding the scene as `export` writes it and every array of the simulation, scratch buffers included, so the exact state of a failing run is kept for inspection. `gs.Scene.load_checkpoint(path)` creates and builds the scene and restores that state:
+
+```python
+scene.save_checkpoint("failing.gstraj")
+```
+
+```python
+scene = gs.Scene.load_checkpoint("failing.gstraj", show_viewer=True)
+scene.step()  # continues from the saved state
+```
+
+A **trajectory** is a checkpoint per step. Register a {py:class}`TrajectoryFile <genesis.options.recorders.TrajectoryFile>` with `scene.start_recording` before the build, and every step appends a frame until `scene.stop_recording()`, which also records the state the run stopped at:
+
+```python
+scene.start_recording(gs.recorders.TrajectoryFile(filename="run.gstraj"))
+scene.build()
+for _ in range(1000):
+    scene.step()
+scene.stop_recording()
+```
+
+The writer runs on the stepping thread, so every frame is kept, and compresses and writes each completed chunk on a thread of its own while the simulation steps on. Two modes trade size for exactness, and `exact` picks one:
+
+- **Exact** (the default for a single environment): every frame holds everything a step reads or writes, so a replay is bit-for-bit and the simulation resumes from any frame.
+- **Compressed** (the default for a batched scene, with a warning): every frame holds the model parameters, configuration, velocities, accelerations, control inputs, contacts, and constraint forces. The file is several times smaller, and a load recomputes the link and geom poses by forward kinematics, which may differ at the last bits.
+
+`hz` records every few steps, `chunk_size` sets how many frames a chunk holds (larger chunks compress better and seek slower), and `max_size` caps the file, closing it as a valid log and raising at the next step past the cap, so a run left recording fills the disk by at most 2 GiB by default. `save_on_reset` starts a new numbered file at every reset of the whole scene, each closing on the state the reset left behind.
+
+`gs.Scene.load_trajectory(path)` creates and builds the recorded scene and returns a {py:class}`Trajectory <genesis.recorders.trajectory.Trajectory>` that plays in it. Frame `i` is the state after `i` steps; `seek(i)` puts the scene there, `play()` seeks every frame and redraws the viewer at the pace the recording ran at, `frame(i)` returns the arrays of a frame by name, and `time(i)` the simulated time of each environment:
+
+```python
+trajectory = gs.Scene.load_trajectory("run.gstraj", show_viewer=True)
+trajectory.seek(500)
+trajectory.scene.step()  # steps on from frame 500 as the recorded run did
+trajectory.play(loop=True)  # replays until the viewer is closed
+```
+
+A trajectory replays on another machine, backend, or precision: the frames are shaped by the options, the description, and the number of environments, and their values are cast to the precision of the session. From the command line, `gs replay run.gstraj` opens the recorded scene in the viewer and plays it in a loop.
 
 ## What a snapshot contains
 
@@ -121,10 +195,11 @@ The dynamic state each solver contributes to a `SimState`:
 
 ## Reproducibility notes
 
-- **Configuration must match.** A snapshot restores fields by position into an already-built scene. The entities, solver options, and environment count must match the scene that produced it. There is no compatibility check: a mismatch fails or silently corrupts state.
+- **Configuration must match.** A snapshot restores fields by position into an already-built scene. The entities, solver options, and environment count must match the scene that produced it. There is no compatibility check: a mismatch fails or silently corrupts state. A checkpoint or a trajectory frame restores arrays by name and checks their shapes, so one from another build is rejected and named.
 - **Precision limits exactness.** Genesis World uses 32-bit floats by default (see {doc}`initialization`). Reproducing a run by stepping a loaded scene, or restoring a snapshot that went through a file, is therefore accurate to roughly single precision, not bit-exact. Initialize with `precision="64"` if you need tighter reproducibility.
 
 ## See also
 
 - {doc}`Parallel simulation </user_guide/getting_started/parallel_simulation>`: how state is batched over environments.
-- {doc}`Scene API </api_reference/engine/scene>`: the full signatures of `get_state`, `reset`, `export`, and `load`.
+- {doc}`Scene API </api_reference/engine/scene>`: the full signatures of `get_state`, `reset`, `export`, `load`, `save_checkpoint`, `load_checkpoint`, and `load_trajectory`.
+- {doc}`Recording data </user_guide/sensing/recorders>`: the recorder framework a trajectory is recorded through.

--- a/source/user_guide/configuration/checkpoints.md
+++ b/source/user_guide/configuration/checkpoints.md
@@ -1,23 +1,23 @@
 # Checkpoints and simulation state
 
-A checkpoint is a snapshot of the dynamic state of a scene at one instant: the numbers the physics solvers advance every step, such as joint positions, velocities, and particle fields. Capturing that snapshot and restoring it later lets you rewind a simulation, reset an environment between episodes, or resume a long run after a crash, deterministically, from the exact state you left.
+A simulation has two things worth keeping. The first is its *dynamic state*: the numbers the physics solvers advance every step, such as joint positions, velocities, and particle fields. Capturing that state and restoring it later lets you rewind a simulation or reset an environment between episodes, deterministically, from the exact state you left. The second is the *scene itself*: the entities, their geometry, and every option the scene was created with. Writing that to a file lets someone else open the very scene you built, on a machine holding none of the assets you built it from.
 
-Genesis World exposes two levels of this. The state model is the same underneath; the difference is where the snapshot lives.
+Genesis World keeps the two apart, because they answer different needs.
 
-- **In memory:** `scene.get_state()` returns a {py:class}`SimState <genesis.engine.states.solvers.SimState>` object, and `scene.reset(state=...)` writes it back. Fast, and the basis of episode resets in reinforcement learning.
-- **On disk:** `scene.save_checkpoint(path)` pickles the full physics state to one file, and `scene.load_checkpoint(path)` restores it into a matching scene. Use it to persist a run across processes.
+- **Dynamic state, in memory:** `scene.get_state()` returns a {py:class}`SimState <genesis.engine.states.solvers.SimState>` object, and `scene.reset(state=...)` writes it back. Fast, and the basis of episode resets in reinforcement learning.
+- **The scene, on disk:** `scene.export(path)` writes a `.gscene` file, and `gs.Scene.load(path)` opens it into a new scene, ready to build. Use it to share a scene, attach one to a bug report, or rebuild one without its assets.
 
-All of these operate on a built scene. Build first, then snapshot.
+A state snapshot assumes the scene it came from is already built. A scene file carries no simulated state, so a scene opened from one stands at the configuration its entities were given, and the state has to be reproduced by stepping it again.
 
 ## State model
 
 A snapshot captures only the *dynamic* state: the fields that change as the simulation steps. It does not capture the scene's *structure*: the entities, their morphs, the solver options, or the number of environments. That structure is fixed by how you build the scene, and restoring a snapshot assumes it is already in place.
 
 - **`SimState`:** the object returned by `scene.get_state()`. It holds one per-solver state object for each active solver, batched over environments.
-- **Dynamic state:** positions, velocities, and the internal fields each solver integrates. This is what a checkpoint saves and restores.
-- **Static structure:** entities, morphs, geometry, and solver configuration. Not saved. Rebuild it exactly before restoring, and it must match.
+- **Dynamic state:** positions, velocities, and the internal fields each solver integrates. This is what a snapshot holds.
+- **Static structure:** entities, morphs, geometry, and solver configuration. A snapshot leaves it out, and a scene file is how it travels (see below).
 
-Because structure is not part of the snapshot, a checkpoint is only valid for a scene built the same way. Restoring into a scene with different entities or solver options is undefined.
+Because structure is not part of the snapshot, a snapshot is only valid for the scene it was taken from, or one built the same way. Restoring into a scene with different entities or solver options is undefined.
 
 ## Snapshot and restore in memory
 
@@ -34,8 +34,10 @@ state = scene.get_state()  # snapshot the state at step 100
 for _ in range(50):
     scene.step()
 
-scene.reset(state=state)  # rewind to the snapshot; the sim continues from step 100
+scene.reset(state=state)  # rewind to the snapshot; the physics continue from there
 ```
+
+A reset also sets the simulated time of the environments it touches back to zero, whichever snapshot it restores, so `scene.get_time()` counts from the reset rather than from the build.
 
 :::{warning}
 Passing `state` to `reset()` also registers it as the scene's initial state. A subsequent bare `scene.reset()` returns to *this* snapshot, not to the state the scene had at build time. Keep a separate reference to your build-time state if you need both.
@@ -74,71 +76,55 @@ for step in range(episode_length):
 
 `envs_idx` applies only to a scene built with environments, so on a non-parallelized scene it raises.
 
-## Saving to disk
+## Sharing a scene as a file
 
-`save_checkpoint` writes the full physics state (the scene's own fields plus every active solver's fields) to a single pickle file. Restoring requires a scene that was built the same way:
-
-```python
-# Process A: run and save.
-scene.build()
-for _ in range(100):
-    scene.step()
-scene.save_checkpoint("run.pkl")
-```
+`scene.export(path)` writes what the scene was authored from and what its build resolved: every entity's description, with its geometry, textures and physical coefficients, beside every option the scene was created with. No filesystem path goes into the file, so it opens on a machine holding none of the meshes, model files or textures the scene came from. `gs.Scene.load(path)` creates that scene, holding every entity it was authored with and waiting to be built:
 
 ```python
-# Process B: rebuild the same scene, then restore.
+# Wherever the scene was authored.
 scene = gs.Scene()
+scene.add_entity(gs.morphs.Plane())
 robot = scene.add_entity(gs.morphs.MJCF(file="xml/franka_emika_panda/panda.xml"))
-scene.build()
-
-scene.load_checkpoint("run.pkl")  # restores state and scene.t
+scene.export("franka.gscene")
 ```
 
-`load_checkpoint` also restores `scene.t`, the simulation step count, so a resumed run reports the correct step index.
+```python
+# Anywhere else, with no asset on disk.
+scene = gs.Scene.load("franka.gscene")
+scene.build(n_envs=16)
+scene.step()
+```
 
-## What a checkpoint contains
+Adding an entity resolves its description, so a scene is exported before it is built as readily as after, and the number of environments is chosen by whoever builds the loaded scene. A scene file is the right thing to attach to a bug report: a maintainer opens it and steps the exact scene you had, with none of your script and none of your assets.
 
-The dynamic state each solver contributes to a snapshot:
+The file names what it holds rather than carrying code to run. Genesis World creates only the options, descriptions and meshes the file declares, and rejects a value that contradicts its declared type, so a scene from a stranger is safe to open. A load also compares the layout of every class the file holds with the current one, and refuses a file written when a class meant something else, naming the class. A file written by another version of Genesis World whose classes still match loads with a warning that the simulation it describes may run differently.
+
+Every option the scene was created with travels as one {py:class}`SceneOptions <genesis.options.scene.SceneOptions>` object, reachable as `scene.options` on any scene. Passing it to `gs.Scene(options=other.options)` creates a scene from what another was created with, which is also how a loaded scene gets its options back.
+
+What a description carries is what travels, and `export` tells you about the rest:
+
+- **Refused, by name:** anything that alters the simulation and that a description leaves out, since a file without it would restore other physics: an emitter, a force field, and any entity that carries no description, which is every entity that is neither rigid nor kinematic.
+- **Written without, with a warning naming it:** what observes or draws the simulation rather than shaping it. A camera, a recorder, a sensor, a callback Genesis World calls at every step, a texture read from an HDR or EXR file, and the visual vertices an entity was given at runtime. Add those back on the loaded scene.
+
+## What a snapshot contains
+
+The dynamic state each solver contributes to a `SimState`:
 
 | Solver | State fields |
 |---|---|
-| Rigid | `qpos`, `dofs_vel`, `dofs_acc`, `links_pos`, `links_quat` |
+| Rigid | `qpos`, `dofs_vel`, `dofs_acc`, `links_pos`, `links_quat`, `friction_ratio` |
+| Kinematic | `qpos`, `dofs_vel`, `links_pos`, `links_quat` |
 | MPM | `pos`, `vel`, `C`, `F`, `Jp`, `active` |
 | SPH | `pos`, `vel`, `active` |
 | PBD | `pos`, `vel`, `free` |
 | FEM | `pos`, `vel`, `active` |
 
-On disk, a checkpoint is a pickled dictionary. The `arrays` entry is a flat map from a `"Class.field"` key to the raw NumPy array of that field:
-
-```python
-{
-    "timestamp": ...,   # time.time() at save
-    "step_index": ...,  # scene.t at save
-    "arrays": {
-        "RigidSolver.qpos": ...,
-        "MPMSolver.pos": ...,
-        # ... one entry per solver field ...
-    },
-}
-```
-
 ## Reproducibility notes
 
-- **Configuration must match.** A checkpoint restores fields by name into an already-built scene. The entities, solver options, and environment count must match the scene that produced it. There is no compatibility check: a mismatch fails or silently corrupts state.
-- **Precision limits exactness.** Genesis World uses 32-bit floats by default (see {doc}`initialization`). A save/load round trip is therefore accurate to roughly single-precision, not bit-exact. Initialize with `precision="64"` if you need tighter reproducibility.
-- **Serialize before pickling a `SimState`.** A `SimState` returned by `get_state()` holds live references back into the scene and its autograd graph. Call `state.serializable()` first to detach the tensors and drop those references, then pickle it yourself. `save_checkpoint` handles this for you.
-
-```python
-state = scene.get_state()
-state.serializable()  # detach tensors; safe to pickle
-
-import pickle
-with open("state.pkl", "wb") as f:
-    pickle.dump(state, f)
-```
+- **Configuration must match.** A snapshot restores fields by position into an already-built scene. The entities, solver options, and environment count must match the scene that produced it. There is no compatibility check: a mismatch fails or silently corrupts state.
+- **Precision limits exactness.** Genesis World uses 32-bit floats by default (see {doc}`initialization`). Reproducing a run by stepping a loaded scene, or restoring a snapshot that went through a file, is therefore accurate to roughly single precision, not bit-exact. Initialize with `precision="64"` if you need tighter reproducibility.
 
 ## See also
 
 - {doc}`Parallel simulation </user_guide/getting_started/parallel_simulation>`: how state is batched over environments.
-- {doc}`Scene API </api_reference/engine/scene>`: the full signatures of `get_state`, `reset`, `save_checkpoint`, and `load_checkpoint`.
+- {doc}`Scene API </api_reference/engine/scene>`: the full signatures of `get_state`, `reset`, `export`, and `load`.

--- a/source/user_guide/configuration/config_system.md
+++ b/source/user_guide/configuration/config_system.md
@@ -44,17 +44,19 @@ You never instantiate `Options` directly; you always use a concrete subclass. Ea
 
 `SimOptions` holds settings that are global by default: most importantly the timestep `dt` (seconds) and `gravity` (m/s², pointing down `-Z`). Each solver also exposes those same settings on its own options object, where they default to `None`.
 
-A value set on a solver's options overrides the global `SimOptions` value, for that solver only, and a solver whose field is left at `None` inherits the global value. This lets most scenes set `dt` once while allowing a single solver to run at a different rate.
+A value set on a solver's options overrides the global `SimOptions` value, for that solver only, and a solver whose field is left at `None` inherits the global value.
+
+`SimOptions.dt` is how much simulated time one `scene.step()` advances. A solver's `dt` is the interval it integrates over, so it must divide the step a whole number of times, and that quotient is the number of substeps per step. Every active solver advances together, so the count one solver asks for is the count they all take, and two solvers asking for different intervals raise. `SimOptions.substeps` requests the same count directly, and setting both raises unless they agree.
 
 ```python
 scene = gs.Scene(
-    sim_options=gs.options.SimOptions(dt=0.01),        # global timestep
-    rigid_options=gs.options.RigidOptions(dt=0.005),   # rigid solver only, overrides the global dt
-    # mpm_options left unset -> the MPM solver, if used, inherits dt=0.01
+    sim_options=gs.options.SimOptions(dt=0.01),        # one step advances 0.01 s
+    rigid_options=gs.options.RigidOptions(dt=0.005),   # two substeps per step, for every solver
+    # mpm_options left unset -> the MPM solver, if used, integrates twice per step as well, over 0.005 s
 )
 ```
 
-The same inheritance applies to `gravity`. Settings that are meaningful only to one solver (for example `RigidOptions.constraint_solver` or `RigidOptions.max_collision_pairs`) live solely on that solver's options and have no global counterpart.
+The same inheritance applies to `gravity`, and each solver keeps its own value, so read it back from the solver simulating the entity, for example `scene.rigid_solver.get_gravity(envs_idx)`. A scene coupling its solvers through IPC applies the `SimOptions` gravity to every body it couples, so a coupled solver authoring a different one raises at build time. Settings that are meaningful only to one solver (for example `RigidOptions.constraint_solver` or `RigidOptions.max_collision_pairs`) live solely on that solver's options and have no global counterpart.
 
 ## Scene-level option groups
 

--- a/source/user_guide/configuration/conventions.md
+++ b/source/user_guide/configuration/conventions.md
@@ -28,7 +28,7 @@ Euler angles, where they are accepted instead, are extrinsic x-y-z in degrees (S
 
 ## Gravity
 
-Gravity defaults to `(0, 0, -9.81)`, i.e. `-Z` with a magnitude of 9.81 m/s². With no other forces applied, objects fall along `-Z`. Set it per scene through `gs.options.SimOptions(gravity=...)`.
+Gravity defaults to `(0, 0, -9.81)`, i.e. `-Z` with a magnitude of 9.81 m/s². With no other forces applied, objects fall along `-Z`. Set it for the whole scene through `gs.options.SimOptions(gravity=...)`, or for one solver through the `gravity` field of its own options, and change it at runtime through that solver, for example `scene.rigid_solver.set_gravity(gravity, envs_idx)`.
 
 ## Axis conversion at import time
 

--- a/source/user_guide/developers/extending_genesis.md
+++ b/source/user_guide/developers/extending_genesis.md
@@ -43,7 +43,7 @@ Because the two callables identify the registration, pass named functions (or ho
 
 ## Writing a custom recorder
 
-The built-in file writers and plotters cover most needs; to capture data any other way, subclass `genesis.recorders.Recorder` and pass your options to `scene.start_recording`. The scene drives a recorder through five methods, so you implement them and never call them yourself:
+The built-in file writers and plotters cover most needs; to capture data any other way, subclass `genesis.recorders.Recorder` and pass your options to `scene.add_recorder`. The scene drives a recorder through five methods, so you implement them and never call them yourself:
 
 1. **`__init__`** configures the recorder from its options.
 2. **`build()`** initializes resources (called during `scene.build()`).

--- a/source/user_guide/interaction/visualization.md
+++ b/source/user_guide/interaction/visualization.md
@@ -67,6 +67,12 @@ gs play xml/franka_emika_panda/panda.xml
 gs animate 'frames/*.png' --fps 60
 ```
 
+**`gs replay file.gstraj`** opens the scene a trajectory was recorded from and replays the recording in the viewer, in a loop, until the viewer is closed. See {doc}`Checkpoints and simulation state </user_guide/configuration/checkpoints>` for recording one.
+
+```bash
+gs replay run.gstraj
+```
+
 :::{note}
 `gs view` still works as a deprecated alias of `gs launch` and prints a deprecation warning. Use `gs launch` instead.
 :::

--- a/source/user_guide/policy_training/best_practices/domain_randomization.md
+++ b/source/user_guide/policy_training/best_practices/domain_randomization.md
@@ -22,26 +22,24 @@ robot.set_friction_ratio(
     links_idx_local=np.arange(0, robot.n_links),
 )
 
-# Perturb each link's mass by a per-env offset in [-0.5, 0.5) kg.
-robot.set_mass_shift(
-    mass_shift=-0.5 + torch.rand(scene.n_envs, robot.n_links),
-    links_idx_local=np.arange(0, robot.n_links),
+# Scale each link's mass by a per-env factor in [0.75, 1.25).
+robot.set_links_mass(
+    mass=robot.get_links_mass() * (0.75 + 0.5 * torch.rand(scene.n_envs, robot.n_links, device=gs.device)),
 )
 
 # Shift each link's center of mass by up to 5 cm on each axis.
-robot.set_COM_shift(
-    com_shift=-0.05 + 0.1 * torch.rand(scene.n_envs, robot.n_links, 3),
-    links_idx_local=np.arange(0, robot.n_links),
+robot.set_links_COM(
+    com=robot.get_links_COM() + (-0.05 + 0.1 * torch.rand(scene.n_envs, robot.n_links, 3, device=gs.device)),
 )
 ```
 
 The three methods differ in what they modify:
 
 - **`set_friction_ratio`:** multiplies each geom's base friction coefficient by the supplied factor, shape `(n_envs, n_links)`. It scales rather than replaces, so a ratio of `1.0` leaves the model's friction unchanged. To set an absolute coefficient for the whole entity instead, use `set_friction(friction)`, which takes a single float and requires it in the range `[1e-2, 5.0]` for stability.
-- **`set_mass_shift`:** adds a mass offset in kg to each link, shape `(n_envs, n_links)`. It shifts the model's mass rather than replacing it.
-- **`set_COM_shift`:** adds a center-of-mass offset in meters to each link, shape `(n_envs, n_links, 3)`, in the link's local frame.
+- **`set_links_mass`:** sets the mass of each link in kg, shape `(n_envs, n_links)`, and leaves its inertia as authored. It takes the mass itself, which is why the example reads the model's masses back with `get_links_mass` and writes scaled ones.
+- **`set_links_COM`:** sets the center of mass of each link in meters, shape `(n_envs, n_links, 3)`, as an offset in the link's local frame. It takes the position itself too, so the example shifts what `get_links_COM` returns.
 
-These three write to per-environment state buffers, so they work whether or not the scene batches its static model info. Pass `envs_idx` to any of them to restrict the update to a subset of environments.
+`set_friction_ratio` writes per-environment state, so it works in any scene. A per-environment mass or center of mass describes the model itself, which Genesis World stores per environment only when the scene is built with `batch_links_info=True` (see the warning below). A single value shared by every environment needs no flag. Pass `envs_idx` to any of them to restrict the update to a subset of environments.
 
 ## Randomizing actuator gains
 
@@ -57,7 +55,7 @@ robot.set_dofs_armature(0.01 + 0.02 * torch.rand(scene.n_envs, robot.n_dofs), mo
 `set_dofs_kp` and `set_dofs_kv` set the position and velocity gains of the PD controller; `set_dofs_armature` sets the reflected motor inertia, which stabilizes stiff joints. The second positional argument is `dofs_idx_local`, the entity-local dof indices to update, matching the `motors_dof_idx` you build from joint names.
 
 :::{warning}
-Per-environment dof gains require batched dof info. The controller gains live in the model's static info fields, which are stored per environment only when the scene is built with the corresponding option. Enable it in {py:class}`RigidOptions <genesis.options.solvers.RigidOptions>`:
+Per-environment dof gains require batched dof info, and per-environment link masses, centers of mass and inertias require batched link info. Both live in the model's static info fields, which are stored per environment only when the scene is built with the corresponding option. Enable it in {py:class}`RigidOptions <genesis.options.solvers.RigidOptions>`:
 
 ```python
 scene = gs.Scene(
@@ -68,7 +66,7 @@ scene = gs.Scene(
 )
 ```
 
-Without `batch_dofs_info=True`, a gain tensor with an `n_envs` dimension has nowhere to go. The state-based setters above (`set_friction_ratio`, `set_mass_shift`, `set_COM_shift`) need no such flag.
+Without `batch_dofs_info=True`, a gain tensor with an `n_envs` dimension has nowhere to go, and the same holds for a per-environment mass, center of mass or inertia without `batch_links_info=True`. `set_friction_ratio` needs neither flag.
 :::
 
 ## Randomizing commands and states per episode
@@ -97,13 +95,14 @@ The same principle applies to spawn poses and reset states: build the randomized
 | Method | Shape | Randomizes |
 |---|---|---|
 | `set_friction_ratio` | `(n_envs, n_links)` | Per-link friction, as a multiplier on the base coefficient |
-| `set_mass_shift` | `(n_envs, n_links)` | Per-link additive mass offset (kg) |
-| `set_COM_shift` | `(n_envs, n_links, 3)` | Per-link center-of-mass offset (m) |
+| `set_links_mass` | `(n_envs, n_links)` | Per-link mass (kg) |
+| `set_links_COM` | `(n_envs, n_links, 3)` | Per-link center of mass (m), in the link frame |
+| `set_links_inertia` | `(n_envs, n_links, 3, 3)` | Per-link inertia matrix, in the inertial frame |
 | `set_dofs_kp` | `(n_envs, n_dofs)` | PD position gain |
 | `set_dofs_kv` | `(n_envs, n_dofs)` | PD velocity gain |
 | `set_dofs_armature` | `(n_envs, n_dofs)` | Reflected motor inertia |
 
-All six accept an optional `envs_idx` to update a subset of environments. The gain and armature setters require `batch_dofs_info=True`; the friction, mass, and COM setters do not.
+All seven accept an optional `envs_idx` to update a subset of environments. The gain and armature setters require `batch_dofs_info=True`, the mass, center of mass and inertia setters require `batch_links_info=True`, and `set_friction_ratio` requires neither.
 
 ## Guidelines
 

--- a/source/user_guide/sensing/recorders.md
+++ b/source/user_guide/sensing/recorders.md
@@ -7,7 +7,7 @@ Recording runs on a background thread by default, so it adds little overhead to 
 The complete runnable example for this page is [`examples/sensors/imu_franka.py`](https://github.com/Genesis-Embodied-AI/genesis-world/blob/main/examples/sensors/imu_franka.py), which logs an IMU sensor to an `.npz` file and plots it live:
 
 ```python
-scene.start_recording(
+scene.add_recorder(
     data_func=lambda: imu.read()._asdict(),
     rec_options=gs.recorders.NPZFile(filename="out/imu_data.npz"),
 )
@@ -17,7 +17,7 @@ That single call captures IMU readings every step and writes them to `out/imu_da
 
 ## How recording works
 
-Every scene owns a **RecorderManager**. Each call to `start_recording` registers one **recorder** with that manager, pairing two things:
+Every scene owns a **RecorderManager**. Each call to `add_recorder` registers one **recorder** with that manager, pairing two things:
 
 - A **data function:** a zero-argument callable that returns the data to capture (a scalar, an array, or a `dict` of them).
 - A **recorder options** object from `gs.recorders`, the *what to do with it*: a file writer or a plotter.
@@ -25,16 +25,16 @@ Every scene owns a **RecorderManager**. Each call to `start_recording` registers
 From then on, the manager drives the recorder for you:
 
 1. On `scene.build()`, the manager builds and starts every registered recorder: files open, plot windows appear.
-2. On each `scene.step()`, the manager calls the data function and hands the result to the recorder at the configured rate.
-3. On `scene.stop_recording()` (or when the scene is destroyed), every recorder flushes and closes cleanly.
+2. Before each `scene.step()`, the manager calls the data function and hands the result to the recorder at the configured rate. A sample is therefore the state a step starts from, with the control inputs the step consumes, whether a setter or a pre-step callback wrote them.
+3. On `scene.stop_recording()` (or when the scene is destroyed), the manager records the state the run stopped at, whatever the sampling rate, then every recorder flushes and closes cleanly. A reset of the whole scene records the state it leaves behind the same way.
 
 Because the manager reads the data function itself, you never call it in your loop. Describe the recording once, before build, and step normally.
 
 :::{warning}
-Set up all recording **before** `scene.build()`. `scene.start_recording` and `sensor.start_recording` assert the scene is unbuilt and raise otherwise, because recorders allocate their file handles and windows during the build.
+Set up all recording **before** `scene.build()`. `scene.add_recorder`, `scene.start_recording`, and `sensor.start_recording` assert the scene is unbuilt and raise otherwise, because recorders allocate their file handles and windows during the build.
 :::
 
-A visualization camera has its own video API, `camera.start_recording()`, which you call *after* build and which bypasses the recorder manager entirely; see {doc}`Recording a video </user_guide/rendering/index>`.
+A visualization camera has its own video API, `camera.start_recording()`, which you call *after* build and which bypasses the recorder manager entirely; see {doc}`Recording a video </user_guide/rendering/index>`. `scene.start_recording` records the scene itself, every array of its simulation at every step, to a file that replays it; see {doc}`Checkpoints and simulation state </user_guide/configuration/checkpoints>`.
 
 ## Recording sensor data
 
@@ -47,7 +47,7 @@ imu.start_recording(gs.recorders.NPZFile(filename="out/imu_data.npz"))
 
 ## Recording arbitrary data
 
-To record anything else, or to combine or preprocess sensor output, use `scene.start_recording` with your own data function. It takes the callable first and the recorder options second:
+To record anything else, or to combine or preprocess sensor output, use `scene.add_recorder` with your own data function. It takes the callable first and the recorder options second:
 
 ```python
 def data_func():
@@ -60,7 +60,7 @@ def data_func():
         "true_ang_vel": true_data.ang_vel,
     }
 
-scene.start_recording(
+scene.add_recorder(
     data_func,
     gs.recorders.MPLLinePlot(
         title="IMU Data",
@@ -83,7 +83,7 @@ Live matplotlib line plot of IMU linear acceleration and angular velocity, measu
 
 ## Available recorders
 
-Pass any of these to `start_recording` as the recorder options. All are exported from `gs.recorders`.
+Pass any of these to `add_recorder` as the recorder options. All are exported from `gs.recorders`.
 
 **File writers** persist data to disk:
 
@@ -92,6 +92,7 @@ Pass any of these to `start_recording` as the recorder options. All are exported
 | {py:class}`NPZFile <genesis.options.recorders.NPZFile>` | `.npz` | Buffers everything and writes once at stop. Handles arrays and dicts of arrays. |
 | {py:class}`CSVFile <genesis.options.recorders.CSVFile>` | `.csv` | One row per sample. Pass `header` to name columns; `save_every_write=True` to flush continuously. |
 | {py:class}`VideoFile <genesis.options.recorders.VideoFile>` | `.mp4` | Streams frames straight to file via PyAV. Data must be a `[H, W]` or `[H, W, 3]` `uint8` image. |
+| {py:class}`TrajectoryFile <genesis.options.recorders.TrajectoryFile>` | `.gstraj` | The state of the scene itself, one frame per step, for `gs.Scene.load_trajectory` to seek and replay. Registered with `scene.start_recording`, since the scene is the data source. |
 
 **Plotters** visualize data live, and can also save the animation via `save_to_filename`:
 
@@ -112,14 +113,16 @@ Every recorder options object accepts a few shared settings:
 
 - `hz`: how often to sample, in samples per second. If omitted, the data function runs every step. Genesis World snaps `hz` to the nearest integer multiple of the timestep and warns if it had to adjust.
 - `save_on_reset` (file writers): when `True`, `scene.reset()` flushes the current file and appends an incrementing counter to the filename, starting a fresh recording per episode.
-- `buffer_size` and `buffer_full_wait_time`: bound the background queue used when recording off-thread.
+- `buffer_size` and `buffer_full_wait_time`: bound the background queue used when recording off-thread. When the queue is full for longer than `buffer_full_wait_time`, the oldest sample is dropped.
 
 ```python
-scene.start_recording(
+scene.add_recorder(
     data_func=lambda: franka.get_qpos(),
     rec_options=gs.recorders.NPZFile(filename="qpos.npz", hz=50),  # 50 samples/second
 )
 ```
+
+A failure on a recorder's background thread, such as a disk that fills up, is raised on the stepping thread at the next step, so a broken recording is reported where the simulation runs.
 
 ## Stopping recording
 


### PR DESCRIPTION
## Description

Documents what per-solver gravity (Genesis PR #3237) and the link mass, center of mass and inertia setters expose to users, and brings the checkpoints page to the scene file that replaced the checkpoint API (Genesis PRs #3288 and #3294):

- `config_system.md`: what a solver-level `dt` means relative to `SimOptions.dt` and `substeps`, that the substep count one solver asks for applies to every solver, and that `gravity` can be authored per solver and read back with `scene.rigid_solver.get_gravity(envs_idx)`, with IPC-coupled scenes as the documented exception.
- `conventions.md`: how to set gravity for one solver and change it at runtime with `set_gravity(gravity, envs_idx)`.
- `domain_randomization.md`: replaces the removed `set_mass_shift` / `set_COM_shift` setters with `set_links_mass`, `set_links_COM` and `set_links_inertia`, aligns the excerpt with `examples/rigid/domain_randomization.py`, and states which setters need `batch_links_info=True`.
- `checkpoints.md`: `scene.save_checkpoint` / `scene.load_checkpoint` are replaced by a section on `scene.export` and `gs.Scene.load`, covering what a `.gscene` file carries, what export refuses or leaves out, how a load checks a file, and `scene.options`. The in-memory snapshot sections stay, with the reset semantics for simulated time and the current per-solver state fields. The `SimState.serializable()` pickling note is dropped, the method being removed.
- `api_reference/engine/scene.md`: adds `SceneOptions` so the new cross-references resolve.

## Screenshot

Text-only changes to existing pages, no new layout.

## Checklist

- [x] I read the [documentation style guide](STYLE_GUIDE.md) and followed it.
- [x] The docs build locally (`make html`) without new warnings.
