### PR TITLE
Document the recorder failure rule, the whole last frame of a trajectory and the scene check of a restore.

### DIFF
--- a/source/user_guide/configuration/checkpoints.md
+++ b/source/user_guide/configuration/checkpoints.md
@@ -167,9 +167,9 @@ The writer runs on the stepping thread, so every frame is kept, and compresses a
 - **Exact** (the default for a single environment): every frame holds everything a step reads or writes, so a replay is bit-for-bit and the simulation resumes from any frame.
 - **Compressed** (the default for a batched scene, with a warning): every frame holds the model parameters, configuration, velocities, accelerations, control inputs, contacts, and constraint forces. The file is several times smaller, and a load recomputes the link and geom poses by forward kinematics, which may differ at the last bits.
 
-`hz` records every few steps, `chunk_size` sets how many frames a chunk holds (larger chunks compress better and seek slower), and `max_size` caps the file, closing it as a valid log and raising at the next step past the cap, so a run left recording fills the disk by at most 2 GiB by default. `save_on_reset` starts a new numbered file at every reset of the whole scene, each closing on the state the reset left behind.
+`hz` records every few steps, `chunk_size` sets how many frames a chunk holds (larger chunks compress better and seek slower), and `max_size` caps the file, closing it as a valid log and raising at the next step past the cap, so a run left recording fills the disk by at most 2 GiB by default.
 
-`gs.Scene.load_trajectory(path)` creates and builds the recorded scene and returns a {py:class}`Trajectory <genesis.recorders.trajectory.Trajectory>` that plays in it. Frame `i` is the state after `i` steps; `seek(i)` puts the scene there, `play()` seeks every frame and redraws the viewer at the pace the recording ran at, `frame(i)` returns the arrays of a frame by name, and `time(i)` the simulated time of each environment:
+`gs.Scene.load_trajectory(path)` creates and builds the recorded scene and returns a {py:class}`Trajectory <genesis.recorders.trajectory.Trajectory>` that plays in it. Frame `i` is the state after `i` steps; `seek(i)` puts the scene there, `play()` seeks every frame and redraws the viewer at the pace the recording ran at, `frame(i)` returns the arrays of a frame by name, and `time(i)` the simulated time of each environment. A negative index counts from the end. The last frame, like a checkpoint file, holds every array but the configs and constants, the scratch of the solvers included, for the analysis of a failure that may depend on the platform and never reproduce once shared:
 
 ```python
 trajectory = gs.Scene.load_trajectory("run.gstraj", show_viewer=True)
@@ -195,7 +195,7 @@ The dynamic state each solver contributes to a `SimState`:
 
 ## Reproducibility notes
 
-- **Configuration must match.** A snapshot restores fields by position into an already-built scene. The entities, solver options, and environment count must match the scene that produced it. There is no compatibility check: a mismatch fails or silently corrupts state. A checkpoint or a trajectory frame restores arrays by name and checks their shapes, so one from another build is rejected and named.
+- **Configuration must match.** A snapshot restores fields by position into an already-built scene. The entities, solver options, and environment count must match the scene that produced it. There is no compatibility check: a mismatch fails or silently corrupts state. A checkpoint or a trajectory frame restores arrays by name and checks their shapes, so one from another build is rejected and named. Both also carry a digest of the scene description, its entities and physics options, and restore only into a scene sharing it, whatever its viewer, visualizer and renderer options. The digest exports the description in memory, meshes included, once per built scene and once per trajectory opened, never per restore.
 - **Precision limits exactness.** Genesis World uses 32-bit floats by default (see {doc}`initialization`). Reproducing a run by stepping a loaded scene, or restoring a snapshot that went through a file, is therefore accurate to roughly single precision, not bit-exact. Initialize with `precision="64"` if you need tighter reproducibility.
 
 ## See also

--- a/source/user_guide/sensing/recorders.md
+++ b/source/user_guide/sensing/recorders.md
@@ -112,7 +112,6 @@ For more usage: camera video and image recording in [`examples/manipulation/gras
 Every recorder options object accepts a few shared settings:
 
 - `hz`: how often to sample, in samples per second. If omitted, the data function runs every step. Genesis World snaps `hz` to the nearest integer multiple of the timestep and warns if it had to adjust.
-- `save_on_reset` (file writers): when `True`, `scene.reset()` flushes the current file and appends an incrementing counter to the filename, starting a fresh recording per episode.
 - `buffer_size` and `buffer_full_wait_time`: bound the background queue used when recording off-thread. When the queue is full for longer than `buffer_full_wait_time`, the oldest sample is dropped.
 
 ```python
@@ -122,7 +121,7 @@ scene.add_recorder(
 )
 ```
 
-A failure on a recorder's background thread, such as a disk that fills up, is raised on the stepping thread at the next step, so a broken recording is reported where the simulation runs.
+A failure of a recorder, a sample or a write that raises, such as a disk that fills up, is raised on the stepping thread: at once from `scene.step()` when the recorder runs there, at the next step or `sync()` when it runs on a background thread. The recorder that failed records no more, a reset of the scene restarts the others, and `scene.stop_recording()` still flushes what it wrote. A reset of the scene never starts a new file: the recording goes on in the same one, with the state re-initialized.
 
 ## Stopping recording
 


### PR DESCRIPTION
Follows Genesis-Embodied-AI/Genesis#3309 as it now stands: a recorder that raises stops for good and the failure reaches the stepping thread, a reset of the scene never starts a new file (`save_on_reset` is gone), the last frame of a trajectory holds every array as a checkpoint file does and is reached with a negative index, and a checkpoint or trajectory restores only into a scene sharing its description digest, whose cost is one in-memory export per built scene.