### PR TITLE
docs: weekly sync with genesis-world (20260907-090701)

### DIFF
--- a/source/api_reference/engine/entity/drone_entity.md
+++ b/source/api_reference/engine/entity/drone_entity.md
@@ -1,7 +1,7 @@
 # DroneEntity
 
 ```{eval-rst}
-.. autoclass:: genesis.engine.entities.drone_entity.DroneEntity
+.. autoclass:: genesis.engine.entities.rigid_entity.drone_entity.DroneEntity
     :members:
     :undoc-members:
     :show-inheritance:

--- a/source/api_reference/engine/entity/index.md
+++ b/source/api_reference/engine/entity/index.md
@@ -18,6 +18,7 @@ Each physics solver has its own entity type. Choosing a material selects the sol
 
 - **`RigidEntity`:** articulated rigid bodies and robots simulated by the rigid solver. It is the type used for most manipulation and locomotion tasks, and it exposes links, joints, and dofs.
 - **`DroneEntity`:** a {py:class}`RigidEntity <genesis.engine.entities.rigid_entity.rigid_entity.RigidEntity>` subclass that adds propeller and thrust control for quadrotor simulation.
+- **`TerrainEntity`:** a {py:class}`RigidEntity <genesis.engine.entities.rigid_entity.rigid_entity.RigidEntity>` subclass backing `gs.morphs.Terrain`, whose height field answers a surface-height query at any point.
 - **`MPMEntity`:** elastic and plastic solids, sand, snow, and similar continua simulated with the Material Point Method (MPM) solver.
 - **`FEMEntity`:** deformable solids simulated with the Finite Element Method (FEM) solver.
 - **PBD entities:** cloth, ropes, and particle-based fluids simulated by the Position Based Dynamics (PBD) solver. The material determines the concrete type: for example `PBD2DEntity` for cloth and `PBD3DEntity` for elastic volumes.
@@ -37,6 +38,7 @@ pbd_entity/index
 sph_entity
 sf_entity
 drone_entity
+terrain_entity
 hybrid_entity
 tool_entity
 emitter

--- a/source/api_reference/engine/entity/terrain_entity.md
+++ b/source/api_reference/engine/entity/terrain_entity.md
@@ -1,0 +1,15 @@
+# TerrainEntity
+
+The entity `scene.add_entity(gs.morphs.Terrain(...))` returns: a rigid entity whose single fixed link is a height field, a grid of elevations that bodies rest on and that answers a height query at any point. For usage, see {doc}`/user_guide/physics/terrain`.
+
+```{eval-rst}
+.. autoclass:: genesis.engine.entities.rigid_entity.terrain_entity.TerrainEntity
+    :members:
+    :undoc-members:
+    :show-inheritance:
+```
+
+## See also
+
+- {doc}`/user_guide/physics/terrain`: building a terrain and querying its surface height.
+- {doc}`/api_reference/engine/entity/morph/file_morph/terrain`: the `gs.morphs.Terrain` morph and its options.

--- a/source/user_guide/assets/loading_assets.md
+++ b/source/user_guide/assets/loading_assets.md
@@ -56,6 +56,14 @@ For articulated models, two URDF options matter for performance and control:
 
 - **`merge_fixed_links`** (default `True`) merges links joined by fixed joints into one rigid body, which is faster. If you need a merged link to stay addressable, for example an end-effector frame you drive with {doc}`inverse kinematics </user_guide/robot_control/inverse_kinematics_motion_planning>`, list it in **`links_to_keep`**.
 
+## Scene files that carry their own ground
+
+An MJCF file describing a whole scene rather than a single robot often authors a ground plane directly under its `<worldbody>`. Pass `exclude_ground_plane=True` to leave those plane geometries out, so the model lands on the {py:class}`gs.morphs.Plane <genesis.options.morphs.Plane>` or {doc}`terrain </user_guide/physics/terrain>` you added yourself rather than on a second floor:
+
+```python
+scene.add_entity(gs.morphs.MJCF(file="scene.xml", exclude_ground_plane=True))
+```
+
 ## How file paths are resolved
 
 A morph's `file` may be an absolute path or a relative one. A relative path is resolved first against your current working directory, and if nothing is found there, against the asset directory bundled with Genesis World (`genesis/assets`). That is why `file="xml/franka_emika_panda/panda.xml"` loads the Franka model that ships with the package without any path setup.

--- a/source/user_guide/configuration/conventions.md
+++ b/source/user_guide/configuration/conventions.md
@@ -113,6 +113,14 @@ The `[n_envs,]` bracket means: **present when the scene is built with multiple e
 
 Methods that read or write per-environment state take an `envs_idx` argument to address a subset of environments. Passing `envs_idx=None` (the default) applies to all of them; passing a tensor of indices selects only those rows along the batch dimension.
 
+## Index arguments
+
+`envs_idx` and the per-entity index arguments (`links_idx_local`, `dofs_idx_local`, `qs_idx_local`, and the like) all follow the same rules, so what works on one works on the others:
+
+- **Forms accepted:** an integer, a `range`, a `slice`, a list or tuple, a NumPy array, or a PyTorch tensor. `None` selects everything.
+- **Negative indices** count from the end, as they do in Python and NumPy: `envs_idx=-1` is the last environment.
+- **Boolean arrays** act as masks, and must have the full length of the dimension they select from.
+
 ## Data types and precision
 
 Tensors returned by the API are **PyTorch tensors** placed on the active device (`gs.device`). Their dtype follows the precision chosen at initialization:

--- a/source/user_guide/overview/installation.md
+++ b/source/user_guide/overview/installation.md
@@ -72,7 +72,7 @@ from typing import TYPE_CHECKING
 import genesis as gs
 
 if TYPE_CHECKING:
-    from genesis.engine.entities.drone_entity import DroneEntity
+    from genesis.engine.entities.rigid_entity.drone_entity import DroneEntity
 ```
 
 ### Circular import error
@@ -123,7 +123,7 @@ To ensure GPU rendering is active:
    ln -s /usr/lib/x86_64-linux-gnu/libcuda.so.1 /usr/lib/x86_64-linux-gnu/libcuda.so
    ```
 
-5. Genesis World tries EGL by default, so you usually do not need to set `PYOPENGL_PLATFORM`. In custom setups (Docker, headless servers) these variables can help:
+5. Genesis World picks the window-less backend of the operating system for you, EGL on Linux and CGL on macOS, so you usually do not need to set `PYOPENGL_PLATFORM`. It accepts `egl`, `osmesa`, `cgl` (macOS only), and `pyglet`, which is the fallback everywhere else. In custom setups (Docker, headless servers) these variables can help:
 
    ```bash
    export NVIDIA_DRIVER_CAPABILITIES=all

--- a/source/user_guide/physics/drone_entity.md
+++ b/source/user_guide/physics/drone_entity.md
@@ -1,6 +1,6 @@
 # Drone entity
 
-A {py:class}`DroneEntity <genesis.engine.entities.drone_entity.DroneEntity>` is a quadrotor whose actuation is its four propeller speeds. Unlike a robot arm, it takes no joint torques or positions: set each propeller's angular velocity in **RPM** (revolutions per minute), and Genesis World converts those speeds into the aerodynamic forces that lift and steer the drone.
+A {py:class}`DroneEntity <genesis.engine.entities.rigid_entity.drone_entity.DroneEntity>` is a quadrotor whose actuation is its four propeller speeds. Unlike a robot arm, it takes no joint torques or positions: set each propeller's angular velocity in **RPM** (revolutions per minute), and Genesis World converts those speeds into the aerodynamic forces that lift and steer the drone.
 
 The examples below use the Crazyflie 2.X model that ships with Genesis World. For the class API, see the {doc}`DroneEntity reference </api_reference/engine/entity/drone_entity>`.
 

--- a/source/user_guide/physics/rigid_bodies.md
+++ b/source/user_guide/physics/rigid_bodies.md
@@ -57,6 +57,8 @@ scene = gs.Scene(
 
 Choose the elliptic `friction_cone` when resting objects have to stay put rather than creeping slowly. Paired with the default Newton `constraint_solver` it also unlocks the `signorini` contact resolution, which we then select by default: friction is bounded by the normal force the contact has developed, so a fast-sliding body decelerates at `friction` times gravity instead of lifting off a flat floor. Set `contact_resolution` explicitly to override that choice.
 
+Two examples isolate what each coefficient buys you: [`examples/rigid/torsional_grasp.py`](https://github.com/Genesis-Embodied-AI/genesis-world/blob/main/examples/rigid/torsional_grasp.py) pinches a ball between two plates and spins it, which a point contact cannot resist without `friction_torsional`, and [`examples/rigid/rolling_coast.py`](https://github.com/Genesis-Embodied-AI/genesis-world/blob/main/examples/rigid/rolling_coast.py) launches two balls rolling side by side, where only the one carrying a `friction_rolling` coefficient coasts to a stop.
+
 The rigid solver governs how these bodies actually push on each other: contact, collision geometry, and constraints. {doc}`Theory and modeling </user_guide/theory/rigid_solver/index>` documents that model, and covers {doc}`contact resolution </user_guide/theory/rigid_solver/constraints>` in full.
 
 ## See also

--- a/source/user_guide/physics/terrain.md
+++ b/source/user_guide/physics/terrain.md
@@ -150,6 +150,25 @@ terrain = scene.add_entity(
 
 `spacing` is the grid step in the mesh's own units, and `oversample` casts extra rays per cell so peaks inside a cell are not missed (memory grows as `oversample²`). Pass `up_axis="y"` for meshes authored Y-up, such as glTF; the function rotates them to Z-up before sampling. Cells with no ray hit come back as `NaN`.
 
+## Querying the surface height
+
+`scene.add_entity(gs.morphs.Terrain(...))` returns a {py:class}`TerrainEntity <genesis.engine.entities.rigid_entity.terrain_entity.TerrainEntity>`, whose `get_terrain_height` reports the elevation of the terrain surface at world-frame x-y positions. It reads the same piecewise-planar surface bodies rest on, so a locomotion policy can use it to know how far the ground is under each foot.
+
+```python
+positions = torch.tensor([[1.0, 1.0], [2.0, 3.5]], device=gs.device)  # x-y, meters
+heights = terrain.get_terrain_height(positions)  # shape ([n_envs,] n_points), meters
+```
+
+Positions are given in the world frame rather than in grid coordinates, since the terrain's translation and yaw are applied to the query. The shape of `positions` decides how the query is batched:
+
+- **`(2,)`:** one point, and the result drops the point dimension.
+- **`(n_points, 2)`:** points shared across every environment.
+- **`(n_envs, n_points, 2)`:** per-environment positions.
+
+Pass `envs_idx` alongside any of them to restrict the query to a subset of environments.
+
+A position up to one grid cell outside the terrain is clamped to its edge. Anything farther out, a position holding `NaN` or infinity, and a terrain tilted more than 0.001 rad from world vertical all report `NaN`.
+
 ## Caching generated terrains
 
 Generating a terrain (the height field, the collision mesh, and the visual mesh) runs every time the scene is built. Pass `name="my_terrain"` to generate it only once for a given set of options and load it from cache on later builds. This holds even when `randomize=True`, so naming a terrain is how you reproduce a randomized one exactly across runs.
@@ -157,5 +176,6 @@ Generating a terrain (the height field, the collision mesh, and the visual mesh)
 ## See also
 
 - {doc}`gs.morphs.Terrain API reference </api_reference/engine/entity/morph/file_morph/terrain>`: every keyword argument.
+- {doc}`TerrainEntity API reference </api_reference/engine/entity/terrain_entity>`: the entity `add_entity` returns, and its height query.
 - {doc}`Hello, Genesis World </user_guide/getting_started/hello_genesis>`: the init–scene–build–step loop these examples assume.
 - {doc}`Locomotion training </user_guide/policy_training/examples/locomotion>`: training a walking policy, where terrain becomes the training ground.

--- a/source/user_guide/policy_training/examples/hover_env.md
+++ b/source/user_guide/policy_training/examples/hover_env.md
@@ -56,7 +56,7 @@ self.drone.set_propellers_rpm((1 + self.actions * 0.8) * 14468.429183500699)
 self.scene.step()
 ```
 
-Learning a fraction of hover RPM rather than an absolute RPM keeps the action range small and centered, which stabilizes early training. See {py:meth}`~genesis.engine.entities.drone_entity.DroneEntity.set_propellers_rpm` for the RPM-to-force conversion.
+Learning a fraction of hover RPM rather than an absolute RPM keeps the action range small and centered, which stabilizes early training. See {py:meth}`~genesis.engine.entities.rigid_entity.drone_entity.DroneEntity.set_propellers_rpm` for the RPM-to-force conversion.
 
 ### Observations
 

--- a/source/user_guide/robot_control/advanced_ik.md
+++ b/source/user_guide/robot_control/advanced_ik.md
@@ -94,7 +94,7 @@ Parallel IK is most effective on a GPU backend, where all environments are solve
 
 Inverse kinematics is built on two lower-level operations the same solver exposes directly, and both are useful on their own for analytic control. Forward kinematics is IK's inverse: it maps a joint configuration to the resulting link poses. The Jacobian relates joint velocities to the end-effector's spatial velocity, which is the quantity IK differentiates to take each step; it also underpins Jacobian-transpose control and manipulability analysis.
 
-Both require an entity created with `requires_jac_and_IK=True`, which is the default for the {py:class}`MJCF <genesis.options.morphs.MJCF>` and {py:class}`URDF <genesis.options.morphs.URDF>` robot morphs.
+Both work on any entity the rigid solver simulates, with nothing to declare on the morph. The Jacobian is a method on the entity, while forward kinematics is a query on the solver, because it evaluates a configuration the solver does not currently hold.
 
 ```python
 ee_link = robot.get_link("hand")
@@ -104,13 +104,13 @@ jacobian = robot.get_jacobian(link=ee_link)  # shape ([n_envs,] 6, n_dofs)
 
 # Forward kinematics: joint configuration -> world-frame link poses.
 qpos = robot.get_qpos()
-links_pos, links_quat = robot.forward_kinematics(qpos)
+links_pos, links_quat = robot.solver.forward_kinematics_query(robot, qpos)
 # links_pos:  shape ([n_envs,] n_links, 3)   link-frame origins, world coordinates
 # links_quat: shape ([n_envs,] n_links, 4)   orientations, (w, x, y, z)
 ```
 
-`get_jacobian` takes an optional `local_point` (a length-3 point in the link's local frame) to evaluate the Jacobian somewhere other than the link origin. `forward_kinematics` accepts `qs_idx_local`, `links_idx_local`, and `envs_idx` to compute a subset of the configuration, links, or environments; the returned poses are in the world frame, consistent with the world-frame `qpos` input.
+`get_jacobian` takes an optional `local_point` (a length-3 point in the link's local frame) to evaluate the Jacobian somewhere other than the link origin. `forward_kinematics_query` returns the pose of every link of the entity and takes `envs_idx` to evaluate a subset of environments; the returned poses are in the world frame, consistent with the world-frame `qpos` input. It restores the configuration the solver holds before returning, so querying a hypothetical configuration leaves the simulation untouched.
 
 :::{note}
-`forward_kinematics` reuses the IK solver's internal buffers, which are allocated the first time you call `inverse_kinematics` on the entity. Solve IK at least once before calling it standalone.
+The `requires_jac_and_IK` morph argument these operations once needed is deprecated. Passing it logs a warning and changes nothing.
 :::

--- a/source/user_guide/theory/rigid_solver/collision_detection.md
+++ b/source/user_guide/theory/rigid_solver/collision_detection.md
@@ -65,8 +65,19 @@ contacts = ball.get_contacts(with_entity=plane)  # only ball-plane contacts
 ```
 
 :::{note}
-With multiple environments, every field carries a leading `n_envs` axis and is padded to the largest contact count across environments, so the same array is rectangular. `valid_mask` (shape `(n_envs, n_contacts)`) marks which rows are real; filter with it before using the data. A single-environment scene returns the fields already trimmed, with no `valid_mask`.
+With multiple environments, every field carries a leading `n_envs` axis and is padded to the largest contact count across environments, so the same array is rectangular. `valid_mask` (shape `(n_envs, n_contacts)`) marks which rows are real; filter with it before using the data. A scene built without environments returns the fields already trimmed, with no `valid_mask`.
 :::
+
+## Reading contacts without a synchronization
+
+Trimming the arrays to the live contact count needs that count on the host, so the call synchronizes the device once per read. Pass `is_padded=True` to skip it. The fields then come back at the fixed capacity the collider allocated rather than at the live count, `valid_mask` is present whether or not the scene is parallelized, and the values are otherwise identical on every backend:
+
+```python
+contacts = ball.get_contacts(is_padded=True)
+mask = contacts["valid_mask"]  # shape ([n_envs,] capacity), True on a real contact
+```
+
+Use it in a training loop that reads contacts every step, where the synchronization is what costs you. For a one-off read while scripting or debugging, the default is easier to work with, because the arrays hold contacts alone.
 
 ## Net contact force per link
 


### PR DESCRIPTION
Automated weekly documentation sync.

Reviews genesis-world source commits `241b64d984fbbceb53ef6dfc0603a7d2333698dc..0ce793b42c945b6848aad624501b2ca756d3e244` for doc-impacting changes.

## Summary of changes

Docs sync complete. Here is what I changed and why.

## Summary

Source range `241b64d..0ce793b4` (v1.2.1 → v1.4.0). Most of the big items in that range were already covered by doc PRs #143–#150, so this pass is the remainder.

### Broken references

**`DroneEntity` moved package** (#3281 split `rigid_entity/` into a subpackage). `genesis/engine/entities/drone_entity.py` is now `genesis/engine/entities/rigid_entity/drone_entity.py`, so the `.. autoclass::` target rendered nothing and the two `{py:class}` / `{py:meth}` cross-references dangled. Updated in `api_reference/engine/entity/drone_entity.md`, `user_guide/physics/drone_entity.md`, `user_guide/policy_training/examples/hover_env.md`, and the `TYPE_CHECKING` import snippet in `user_guide/overview/installation.md`.

### Stale API

**`robot.forward_kinematics()` no longer exists** (#3233). It is now `scene.rigid_solver.forward_kinematics_query(entity, qpos, envs_idx=None)`, without the `qs_idx_local` / `links_idx_local` arguments, and it restores the live configuration before returning. The same commit deprecated `requires_jac_and_IK`, which now only logs a warning, so `advanced_ik.md` no longer claims the Jacobian and FK require it. Dropped the note about solving IK once first: the scratch buffers come from the data manager at build.

### New public API

- **`TerrainEntity.get_terrain_height()`** (#3128) was undocumented, along with the entity class itself. Added a "Querying the surface height" section to `physics/terrain.md` covering the three accepted `positions` shapes, `envs_idx`, the world-frame convention, and the `NaN` cases, plus a new `api_reference/engine/entity/terrain_entity.md` page wired into the entity toctree and type list.
- **`get_contacts(is_padded=True)`** (#3253) in `theory/rigid_solver/collision_detection.md`: the fixed-capacity layout that skips the per-read device synchronization. Also corrected the existing note, which said "a single-environment scene" where the source means a scene built without environments.
- **Negative indices and boolean masks** on every index argument (#3165, #3117), as a new section in `configuration/conventions.md`.
- **`MJCF(exclude_ground_plane=True)`** (#3050) in `assets/loading_assets.md`, for scene files that author their own floor.
- **`PYOPENGL_PLATFORM`** now accepts `egl`, `osmesa`, `cgl`, and `pyglet`, defaulting per OS (#3238, #3242, #3302). Updated the troubleshooting step in `installation.md`, which claimed EGL unconditionally.
- Linked the two new friction examples (`torsional_grasp.py`, `rolling_coast.py`, #3069) from `physics/rigid_bodies.md`, which already documented the coefficients but had nothing runnable to point at.

## Left out, with reasons

- **The source checkout at `/home/trinity/Documents/Genesis` is behind the diff tip.** It sits after #3294 but before #3309, and `version.py` reads 1.3.3. Anything from #3309, #3313, #3318, #3319, #3321, or #3322 I could only read from the patch, not verify against a working tree. `checkpoints.md` and `sensing/recorders.md` already match #3309 (`scene.add_recorder`, the `TrajectoryFile` / `scene.start_recording` split, `gs replay`) from doc PR #150, so I left them alone.
- **`relative=` on the pose, velocity, and acceleration getters (#3250).** This is a breaking change, but documenting it properly means first introducing morph `offset_pos` / `offset_quat`, which no page currently mentions. It wants its own section rather than a sentence bolted onto an existing one.
- **`RigidEntity.attach(pos=..., quat=...)` (#3041).** `attach` has never appeared in user-guide prose at all, only in autodoc, so adding the new mounting transform would mean writing the whole feature up from scratch.
- **`RigidOptions.enable_contact_patch`.** The docstring calls it discouraged and it reaches readers through the `RigidOptions` autodoc; promoting it into the collision-detection theory page seemed like the wrong emphasis.

---
_Opened as a draft by the weekly doc-check cron job. Review carefully before merging._
