### PR TITLE
Document opening an exported scene with 'gs launch'.

### DIFF
--- a/source/user_guide/interaction/visualization.md
+++ b/source/user_guide/interaction/visualization.md
@@ -49,7 +49,7 @@ scene.viewer.set_camera_pose(pos=(3.5, 0.0, 2.5), lookat=(0, 0, 0.5))
 
 Installing Genesis World adds a `gs` command with a few subcommands, so you can open the viewer without writing a script. Run `gs` with no arguments to list them.
 
-**`gs launch [asset]`** opens an asset in the interactive viewer. It accepts a Mesh, URDF, MJCF, or USD file, and for a USD stage it loads every rigid entity in the stage. The viewer's overlay exposes per-joint sliders and play, pause, step, and reset controls, and it starts paused so you can inspect and pose the asset first. With no file, it opens an empty scene to which you can add entities live. Useful flags: `-c` visualize collision geometry, `-r` slowly rotate the asset, `-s SCALE` scale it, and `-l` show link frames.
+**`gs launch [asset]`** opens an asset in the interactive viewer. It accepts a Mesh, URDF, MJCF, or USD file, and for a USD stage it loads every rigid entity in the stage. It also opens a `.gscene` file written by `scene.export`, with every entity and physics option the scene was exported with (see {doc}`Checkpoints and simulation state </user_guide/configuration/checkpoints>`). The viewer's overlay exposes per-joint sliders and play, pause, step, and reset controls, and it starts paused so you can inspect and pose the asset first. With no file, it opens an empty scene to which you can add entities live. Useful flags: `-c` visualize collision geometry, `-r` slowly rotate the asset, `-s SCALE` scale it, and `-l` show link frames.
 
 ```bash
 gs launch xml/franka_emika_panda/panda.xml


### PR DESCRIPTION
The `gs launch` paragraph of the visualization guide now says that a `.gscene` file written by `scene.export` opens the same way as an asset, with every entity and physics option the scene was exported with. Companion of Genesis-Embodied-AI/Genesis PR moving `.gscene` opening from `gs play` to `gs launch`.